### PR TITLE
Revoke on stop option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,17 @@ This change log follows the conventions of [keepachangelog.com](http://keepachan
 
 ## [Unreleased]
 
-...
+## [0.4.1] - 2017-05-10
+
+### Added
+- The HTTP Vault client component accepts a `:revoke-on-stop?` option to control
+  the outstanding lease revocation.
+
+### Changed
+- Outstanding leases are no longer revoked on client stop by default.
+- The default lease check period and renewal window changed to one and five
+  minutes, respectively. This allows for better lease utilization, as the
+  previous twenty minute window was too large for short-lived leases.
 
 ## [0.4.0] - 2017-01-06
 
@@ -107,7 +117,8 @@ With this version, the project has been forked to the Amperity organization.
 ### Added
 - Initial library implementation.
 
-[Unreleased]: https://github.com/amperity/vault-clj/compare/0.4.0...HEAD
+[Unreleased]: https://github.com/amperity/vault-clj/compare/0.4.1...HEAD
+[0.4.1]: https://github.com/amperity/vault-clj/compare/0.4.0...0.4.1
 [0.4.0]: https://github.com/amperity/vault-clj/compare/0.3.4...0.4.0
 [0.3.4]: https://github.com/amperity/vault-clj/compare/0.3.3...0.3.4
 [0.3.3]: https://github.com/amperity/vault-clj/compare/0.3.2...0.3.3

--- a/src/vault/client/http.clj
+++ b/src/vault/client/http.clj
@@ -239,9 +239,9 @@
       ; Already running
       this
       ; Start lease heartbeat thread.
-      (let [window (:lease-renewal-window this (* 20 60))
-            period (:lease-check-period   this (*  5 60))
-            jitter (:lease-check-jitter   this (*  1 60))
+      (let [window (:lease-renewal-window this 300)
+            period (:lease-check-period   this  60)
+            jitter (:lease-check-jitter   this  10)
             thread (timer/start! "vault-lease-timer"
                                  #(maintain-leases! this window)
                                  period

--- a/src/vault/env.clj
+++ b/src/vault/env.clj
@@ -19,13 +19,15 @@
   "URI specifying the location of the Vault server to use.")
 
 (defenv :vault-token
-  "A Vault authentication token which should be used directly by the client.")
+  "A Vault authentication token which should be used directly by the client."
+  :secret true)
 
 (defenv :vault-app-id
-  "The public half of an app-id credential for machine auth.")
+  "The public half of an app-id authentication credential.")
 
 (defenv :vault-user-id
-  "The secret half of an app-id credential for machine auth.")
+  "The secret half of an app-id authentication credential."
+  :secret true)
 
 
 (defn ^:deprecated init-app-client


### PR DESCRIPTION
This changes the default behavior of the HTTP client so it no longer tries to revoke all outstanding secrets on component stop. This can be controlled with a new option, if desired.