### PR TITLE
HTTP client request opts

### DIFF
--- a/src/vault/client/http.clj
+++ b/src/vault/client/http.clj
@@ -98,6 +98,7 @@
     method
     (str (:api-url client) "/v1/" path)
     (merge
+      (:http-opts client)
       {:accept :json
        :as :json}
       req
@@ -122,40 +123,44 @@
 
 (defn- authenticate-token!
   "Updates the token ref by storing the given auth token."
-  [auth-ref token]
+  [client token]
   (when-not (string? token)
     (throw (IllegalArgumentException. "Token credential must be a string")))
-  (reset! auth-ref {:client-token (str/trim token)}))
+  (reset! (:auth client) {:client-token (str/trim token)}))
 
 
 (defn- authenticate-userpass!
   "Updates the token ref by making a request to authenticate with a username
   and password."
-  [auth-ref api-url credentials]
+  [client credentials]
   (let [{:keys [username password]} credentials]
     (api-auth!
       (str "user " username)
-      auth-ref
-      (do-api-request :post (str api-url "/v1/auth/userpass/login/" username)
-        {:form-params {:password password}
-         :content-type :json
-         :accept :json
-         :as :json}))))
+      (:auth client)
+      (do-api-request :post (str (:api-url client) "/v1/auth/userpass/login/" username)
+        (merge
+          (:http-opts client)
+          {:form-params {:password password}
+           :content-type :json
+           :accept :json
+           :as :json})))))
 
 
 (defn- authenticate-app!
   "Updates the token ref by making a request to authenticate with an app-id and
   secret user-id."
-  [auth-ref api-url credentials]
+  [client credentials]
   (let [{:keys [app user]} credentials]
     (api-auth!
       (str "app-id " app)
-      auth-ref
-      (do-api-request :post (str api-url "/v1/auth/app-id/login")
-        {:form-params {:app_id app, :user_id user}
-         :content-type :json
-         :accept :json
-         :as :json}))))
+      (:auth client)
+      (do-api-request :post (str (:api-url client) "/v1/auth/app-id/login")
+        (merge
+          (:http-opts client)
+          {:form-params {:app_id app, :user_id user}
+           :content-type :json
+           :accept :json
+           :as :json})))))
 
 
 
@@ -213,17 +218,19 @@
 
 ;; ## HTTP Client Type
 
-;; - `:api-url`
+;; - `api-url`
 ;;   The base URL for the Vault API endpoint.
-;; - `:auth`
+;; - `http-opts`
+;;   Extra options to pass to `clj-http` requests.
+;; - `auth`
 ;;   An atom containing the authentication lease information, including the
 ;;   client token.
-;; - `:leases`
+;; - `leases`
 ;;   Local in-memory storage of secret leases.
-;; - `:lease-timer`
+;; - `lease-timer`
 ;;   Thread which periodically checks and renews leased secrets.
 (defrecord HTTPClient
-  [api-url auth leases lease-timer]
+  [api-url http-opts auth leases lease-timer]
 
   component/Lifecycle
 
@@ -278,8 +285,9 @@
   (status
     [this]
     (-> (do-api-request :get (str api-url "/v1/sys/health")
-          {:accept :json
-           :as :json})
+          (assoc http-opts
+                 :accept :json
+                 :as :json))
         (clean-body)))
 
 
@@ -481,6 +489,8 @@
 
   Client behavior may be controlled with the options:
 
+  - `:http-opts`
+    Additional options to pass to `clj-http` requests.
   - `:lease-renewal-window`
     Period in seconds to renew leases before they expire.
   - `:lease-check-period`

--- a/src/vault/client/http.clj
+++ b/src/vault/client/http.clj
@@ -274,9 +274,9 @@
   (authenticate!
     [this auth-type credentials]
     (case auth-type
-      :token (authenticate-token! auth credentials)
-      :app-id (authenticate-app! auth api-url credentials)
-      :userpass (authenticate-userpass! auth api-url credentials)
+      :token (authenticate-token! this credentials)
+      :app-id (authenticate-app! this credentials)
+      :userpass (authenticate-userpass! this credentials)
       ; Unknown type
       (throw (ex-info (str "Unsupported auth-type " (pr-str auth-type))
                       {:auth-type auth-type})))


### PR DESCRIPTION
Fixes #10

```clojure
=> (require '[vault.core :as vault] 'vault.client.http)
=> (def client (vault/new-client "https://localhost:8200"))

=> (vault/status client)
; SunCertPathBuilderException: unable to find valid certification path to requested target
; sun.security.provider.certpath.SunCertPathBuilder.build (SunCertPathBuilder.java:141)

=> (alter-var-root #'client assoc :http-opts {:insecure? true})

=> (vault/status client)
{:cluster-id "1e40d6e6-d202-7aff-5d1c-ae061b991310",
 :cluster-name "vault-cluster-b031f813",
 :initialized true,
 :sealed false,
 :server-time-utc 1498863935,
 :standby false,
 :version "0.6.4"}
```