### PR TITLE
Secret not found support

### DIFF
--- a/src/vault/client/mock.clj
+++ b/src/vault/client/mock.clj
@@ -152,7 +152,10 @@
   (read-secret
     [this path opts]
     (or (get @memory path)
-        (throw (ex-info (str "No such secret: " path) {:secret path}))))
+        (if (contains? opts :not-found)
+          (:not-found opts)
+          (throw (ex-info (str "No such secret: " path)
+                          {:secret path})))))
 
   (write-secret!
     [this path data]

--- a/src/vault/core.clj
+++ b/src/vault/core.clj
@@ -133,13 +133,19 @@
   (read-secret
     [client path]
     [client path opts]
-    "Reads a secret from a path. Returns the full map of stored secret data.
+    "Reads a secret from a path. Returns the full map of stored secret data if
+    the secret exists, or throws an exception if not.
+
     Additional options may include:
 
-    - `:renew` whether or not to renew this secret when the lease is near
-      expiry.
-    - `:rotate` whether or not to rotate this secret when the lease is near
-      expiry and cannot be renewed.")
+    - `:not-found`
+      If the requested path is not found, return this value instead of throwing
+      an exception.
+    - `:renew`
+      Whether or not to renew this secret when the lease is near expiry.
+    - `:rotate`
+      Whether or not to rotate this secret when the lease is near expiry and
+      cannot be renewed.")
 
   (write-secret!
     [client path data]


### PR DESCRIPTION
Add support for a `:not-found` option in `read-secret` and clarify the contract. If `:not-found` is not set and a secret is missing, both clients throw an exception now, otherwise they will return the supplied value.

Fixes #7 