### PR TITLE
Add support for authenticating via Kubernetes

### DIFF
--- a/src/vault/client/http.clj
+++ b/src/vault/client/http.clj
@@ -197,6 +197,28 @@
            :as :json})))))
 
 
+(defn- authenticate-k8s!
+  "Updates the token ref by authenticating via the kubernetes authentication
+  backend using a JWT."
+  [client credentials]
+  (let [{:keys [api-path jwt role]} credentials
+        api-path (or api-path "/v1/auth/kubernetes/login")]
+    (when-not jwt
+      (throw (IllegalArgumentException. "Kubernetes auth credentials must include :jwt")))
+    (when-not role
+      (throw (IllegalArgumentException. "Kubernetes auth credentials must include :role")))
+    (api-auth!
+      (str "Kubernetes auth role=" role)
+      (:auth client)
+      (do-api-request :post (str (:api-url client) api-path)
+        (merge
+          (:http-opts client)
+          {:form-params {:jwt jwt :role role}
+           :content-type :json
+           :accept :json
+           :as :json})))))
+
+
 ;; ## Timer Logic
 
 (defn- try-renew-lease!
@@ -312,6 +334,7 @@
       :app-role (authenticate-app-role! this credentials)
       :userpass (authenticate-userpass! this credentials)
       :ldap (authenticate-ldap! this credentials)
+      :k8s (authenticate-k8s! this credentials)
       ; Unknown type
       (throw (ex-info (str "Unsupported auth-type " (pr-str auth-type))
                       {:auth-type auth-type})))

--- a/src/vault/core.clj
+++ b/src/vault/core.clj
@@ -17,6 +17,7 @@
     - `:token \"...\"`
     - `:userpass {:username \"user\", :password \"hunter2\"}`
     - `:ldap {:username \"LDAP username\", :password \"hunter2\"}`
+    - `:k8s {:jwt \"...\", :role \"...\"}`
     - `:app-id {:app \"foo-service-dev\", :user \"...\"}`
     - `:app-role {:role-id \"...\", :secret-id \"...\"}")
 


### PR DESCRIPTION
This makes it easy to authenticate to Vault from within a service running in Kubernetes.

See: https://www.vaultproject.io/docs/auth/kubernetes.html