### PR TITLE
Add wrap token config support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
 
   :dependencies
   [[org.clojure/clojure "1.8.0"]
-   [org.clojure/tools.logging "0.3.1"]
+   [org.clojure/tools.logging "0.4.0"]
    [amperity/envoy "0.3.1"]
    [cheshire "5.7.1"]
    [clj-http "2.3.0"]

--- a/src/vault/client/http.clj
+++ b/src/vault/client/http.clj
@@ -91,7 +91,9 @@
              (str "API path must be a non-empty string, got: "
                   (pr-str path)))))
   ; Check client authentication.
-  (when-not (some-> client :auth deref :client-token)
+  (when-not (or
+              (some-> req :headers keys set (contains? "X-Vault-Token"))
+              (some-> client :auth deref :client-token))
     (throw (IllegalStateException.
              "Cannot call API path with unauthenticated client.")))
   ; Call API with standard arguments.
@@ -102,7 +104,7 @@
       (:http-opts client)
       {:accept :json
        :as :json}
-      req
+      (dissoc req :headers)
       {:headers (merge {"X-Vault-Token" (:client-token @(:auth client))}
                        (:headers req))})))
 

--- a/src/vault/client/http.clj
+++ b/src/vault/client/http.clj
@@ -9,7 +9,10 @@
     (vault
       [core :as vault]
       [lease :as lease]
-      [timer :as timer])))
+      [timer :as timer]))
+  (:import
+    (org.apache.commons.codec.digest
+      DigestUtils)))
 
 
 ;; ## API Utilities
@@ -187,7 +190,7 @@
   [client credentials]
   (let [{:keys [role-id secret-id]} credentials]
     (api-auth!
-      (str "role-id " role-id)
+      (str "role-id sha256:" (DigestUtils/sha256Hex role-id))
       (:auth client)
       (do-api-request :post (str (:api-url client) "/v1/auth/approle/login")
         (merge

--- a/src/vault/core.clj
+++ b/src/vault/core.clj
@@ -15,6 +15,7 @@
     credentials. Possible arguments:
 
     - `:token \"...\"`
+    - `:wrap-token \"...\"`
     - `:userpass {:username \"user\", :password \"hunter2\"}`
     - `:ldap {:username \"LDAP username\", :password \"hunter2\"}`
     - `:app-id {:app \"foo-service-dev\", :user \"...\"}`

--- a/src/vault/env.clj
+++ b/src/vault/env.clj
@@ -22,6 +22,10 @@
   "A Vault authentication token which should be used directly by the client."
   :secret true)
 
+(defenv :wrap-vault-token
+  "A token used to lookup a wrapped token creation response containing authentication `:token`."
+  :secret true)
+
 (defenv :vault-app-id
   "The public half of an app-id authentication credential.")
 
@@ -58,6 +62,8 @@
       (cond
         (env :vault-token)
           (vault/authenticate! client :token (env :vault-token))
+        (env :wrap-vault-token)
+          (vault/authenticate! client :wrap-token (env :wrap-vault-token))
         (and (env :vault-app-id) (env :vault-user-id))
           (vault/authenticate! client :app-id {:app (env :vault-app-id)
                                                :user (env :vault-user-id)})

--- a/src/vault/env.clj
+++ b/src/vault/env.clj
@@ -22,7 +22,7 @@
   "A Vault authentication token which should be used directly by the client."
   :secret true)
 
-(defenv :wrap-vault-token
+(defenv :vault-wrap-token
   "A token used to lookup a wrapped token creation response containing authentication `:token`."
   :secret true)
 
@@ -69,8 +69,8 @@
       (cond
         (env :vault-token)
           (vault/authenticate! client :token (env :vault-token))
-        (env :wrap-vault-token)
-          (vault/authenticate! client :wrap-token (env :wrap-vault-token))
+        (env :vault-wrap-token)
+          (vault/authenticate! client :wrap-token (env :vault-wrap-token))
         (and (env :vault-app-id) (env :vault-user-id))
           (vault/authenticate! client :app-id {:app (env :vault-app-id)
                                                :user (env :vault-user-id)})

--- a/src/vault/env.clj
+++ b/src/vault/env.clj
@@ -33,6 +33,13 @@
   "The secret half of an app-id authentication credential."
   :secret true)
 
+(defenv :vault-role-id
+  "The semi-private role-id half of an app-role authentication credential.")
+
+(defenv :vault-secret-id
+  "The secret half of an app-role authentication credential."
+  :secret true)
+
 
 (defn ^:deprecated init-app-client
   "Initialize and auth a new HTTP Vault client. Returns nil if the `:vault-addr`
@@ -67,6 +74,9 @@
         (and (env :vault-app-id) (env :vault-user-id))
           (vault/authenticate! client :app-id {:app (env :vault-app-id)
                                                :user (env :vault-user-id)})
+        (and (env :vault-role-id) (env :vault-secret-id))
+          (vault/authenticate! client :app-role {:role-id (env :vault-role-id)
+                                                 :secret-id (env :vault-secret-id)})
         :else
           (log/warn "No authentication information found in environment!"))
       client)))


### PR DESCRIPTION
Adding top-level support to using a wrapping token to authenticate with vault. This is useful in the case of single-run jobs being passed a credential to do worth without requiring secrets in the job's environment or configuration.

Incidentally fixed `unwrap!` to use the passed-in token as `X-Vault-Token` which currently fails for an unauthenticated client.

Also while I'm at it adding app-role config-client support.