### PR TITLE
Renewing the client token should update the internal auth state

### DIFF
--- a/src/vault/client/http.clj
+++ b/src/vault/client/http.clj
@@ -421,9 +421,14 @@
 
   (renew-token
     [this]
-    (-> (api-request this :post "auth/token/renew-self" {})
-        (clean-body)
-        (:auth)))
+    (let [response (api-request this :post "auth/token/renew-self" {})
+          auth-info (:auth (clean-body response))]
+      (when-not (:client-token auth-info)
+        (throw (ex-info (str "No client token returned from token renewal response: "
+                             (:status response) " " (:reason-phrase response))
+                        {:body (:body response)})))
+      (reset! auth auth-info)
+      auth-info))
 
 
   (renew-token

--- a/src/vault/core.clj
+++ b/src/vault/core.clj
@@ -71,9 +71,13 @@
   (renew-token
     [client]
     [client token]
-    "Renews a lease associated with a token. This is used to prevent the
-    expiration of a token, and the automatic revocation of it. Token renewal is
-    possible only if there is a lease associated with it.")
+    "Renews a lease associated with a token. Returns the renewed auth
+    information. If `token` is not provided, this renews the client's own auth
+    token and updates the internal client authentication state.
+
+    This is used to prevent the expiration of a token, and the automatic
+    revocation of it. Token renewal is possible only if there is a lease
+    associated with it.")
 
   (revoke-token!
     [client]


### PR DESCRIPTION
This fixes the log/vault spam issue with periodic tokens and app-role services.