### PR TITLE
move authenticate dispatch to multimethod for external dispatch

### DIFF
--- a/src/vault/client/http.clj
+++ b/src/vault/client/http.clj
@@ -62,7 +62,7 @@
       ex)))
 
 
-(defn- do-api-request
+(defn do-api-request
   "Performs a request against the API, following redirects at most twice. The
   `request-url` should be the full API endpoint."
   [method request-url req]
@@ -124,7 +124,7 @@
 
 ;; ## Authentication Methods
 
-(defn- api-auth!
+(defn api-auth!
   [claim auth-ref response]
   (let [auth-info (lease/auth-lease (:auth (clean-body response)))]
     (when-not (:client-token auth-info)


### PR DESCRIPTION
In support of adding a small extension to vault-clj, open up authenticate! dispatching.

Eg, an external library could implement `vault.client.http.authenticate-type!` for aws instance auth with:

```clojure
(:require '[big-annoying-aws-library :as aws])

(defmethod vault.client.http.authenticate-type! :aws-iam
    [client _ credentials]
    (let [{:keys [iam-role] credentials]
        (aws/do-instance-authentication-hoop-jumping iam-role))
```