### PR TITLE
Upgrade dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This change log follows the conventions of [keepachangelog.com](http://keepachan
 
 ## [Unreleased]
 
+### Changed
+- Upgrade Clojure to 1.10.0.
+- Upgrade `clj-http` to 3.7.0.
+- Drop dependency on `digest` library.
+- Other minor dependency updates.
+
+## [0.6.6] - ???
+
 ...
 
 ## [0.6.5] - 2018-11-5

--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
    [org.clojure/tools.logging "0.4.0"]
    [amperity/envoy "0.3.1"]
    [cheshire "5.8.0"]
-   [clj-http "2.3.0"]
+   [clj-http "3.7.0"]
    [com.stuartsierra/component "0.3.2"]]
 
   :codox

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
   :pedantic? :abort
 
   :dependencies
-  [[org.clojure/clojure "1.9.0"]
+  [[org.clojure/clojure "1.10.0"]
    [org.clojure/tools.logging "0.4.0"]
    [amperity/envoy "0.3.1"]
    [cheshire "5.8.0"]

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,6 @@
    [amperity/envoy "0.3.1"]
    [cheshire "5.8.0"]
    [clj-http "2.3.0"]
-   [digest "1.4.8"]
    [com.stuartsierra/component "0.3.2"]]
 
   :codox

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject amperity/vault-clj "0.6.5-SNAPSHOT"
+(defproject amperity/vault-clj "0.7.0-SNAPSHOT"
   :description "Clojure client for the Vault secret management system."
   :url "https://github.com/amperity/vault-clj"
   :license {:name "Apache License"
@@ -10,10 +10,10 @@
   :dependencies
   [[org.clojure/clojure "1.10.0"]
    [org.clojure/tools.logging "0.4.0"]
-   [amperity/envoy "0.3.1"]
-   [cheshire "5.8.0"]
+   [amperity/envoy "0.3.3"]
+   [cheshire "5.8.1"]
    [clj-http "3.7.0"]
-   [com.stuartsierra/component "0.3.2"]]
+   [com.stuartsierra/component "0.4.0"]]
 
   :codox
   {:metadata {:doc/format :markdown}
@@ -30,7 +30,7 @@
 
    :repl
    {:source-paths ["dev"]
-    :dependencies [[org.clojure/tools.namespace "0.2.11"]]
+    :dependencies [[org.clojure/tools.namespace "0.3.0"]]
     :jvm-opts ["-Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.SimpleLog"
                "-Dorg.apache.commons.logging.simplelog.showdatetime=true"
                "-Dorg.apache.commons.logging.simplelog.defaultlog=info"

--- a/src/vault/client/http.clj
+++ b/src/vault/client/http.clj
@@ -561,7 +561,7 @@
                       :content-type :json})]
       (log/debug "Wrote secret" path)
       (lease/remove-path! leases path)
-      (case  (:status response)
+      (case (int (:status response -1))
         204 true
         200 (:body response)
         false)))

--- a/src/vault/client/http.clj
+++ b/src/vault/client/http.clj
@@ -6,10 +6,12 @@
     [clojure.tools.logging :as log]
     [clojure.walk :as walk]
     [com.stuartsierra.component :as component]
-    [digest :as digest]
     [vault.core :as vault]
     [vault.lease :as lease]
-    [vault.timer :as timer]))
+    [vault.timer :as timer])
+  (:import
+    java.security.MessageDigest
+    org.apache.commons.codec.binary.Hex))
 
 
 ;; ## API Utilities
@@ -26,6 +28,15 @@
           (into {} (map xf-entry) x)
           x))
       value)))
+
+
+(defn- sha-256
+  "Geerate a SHA-2 256 bit digest from a string."
+  [s]
+  (let [hasher (MessageDigest/getInstance "SHA-256")
+        str-bytes (.getBytes (str s) "UTF-8")]
+    (.update hasher str-bytes)
+    (Hex/encodeHexString (.digest hasher))))
 
 
 (defn- clean-body
@@ -200,7 +211,7 @@
   [client _ credentials]
   (let [{:keys [role-id secret-id]} credentials]
     (api-auth!
-      (str "role-id sha256:" (digest/sha-256 role-id))
+      (str "role-id sha256:" (sha-256 role-id))
       (:auth client)
       (do-api-request
         :post (str (:api-url client) "/v1/auth/approle/login")


### PR DESCRIPTION
This is mostly aimed at upgrading `clj-http` to the 3.X series to unblock usage with Riemann 0.3.X, but also includes a couple other dependency upgrades. I've also removed the dependency on `digest` by doing the (small) amount of Java interop necessary to calculate a SHA-256 hash directly.