### PR TITLE
KV-V2 Metadata CRUD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This change log follows the conventions of [keepachangelog.com](http://keepachan
   [#35](https://github.com/amperity/vault-clj/pull/35)
 - Added support for the KV V2 API
   [#33](https://github.com/amperity/vault-clj/issues/33)
+  [#39](https://github.com/amperity/vault-clj/issues/39)
 - Added support for externally defined secret engines
   [#33](https://github.com/amperity/vault-clj/issues/33)
 - Bugfix for mocking delete

--- a/src/vault/client/api_util.clj
+++ b/src/vault/client/api_util.clj
@@ -15,18 +15,18 @@
 
 ;; ## API Utilities
 
-(defmacro supports-not-found
-  "Tries to-try, and if a 404 occurs, looks for :not-found in to-try-opts"
-  [to-try to-try-opts]
-  (let [try-map (gensym 'api-options)]
+(defmacro support-not-found
+  "Tries to perform the api call, and if a 404 occurs, looks for :not-found in on-fail-opts"
+  [vault-api-call on-fail-opts]
+  (let [fail-map (gensym 'api-options)]
     `(try
-       ~to-try
+       ~vault-api-call
        (catch ExceptionInfo ex#
-         (let [~try-map ~to-try-opts]
-           (if (and (contains? ~try-map :not-found)
+         (let [~fail-map ~on-fail-opts]
+           (if (and (contains? ~fail-map :not-found)
                     (= ::api-error (:type (ex-data ex#)))
                     (= 404 (:status (ex-data ex#))))
-             (:not-found ~try-map)
+             (:not-found ~fail-map)
              (throw ex#)))))))
 
 

--- a/src/vault/client/api_util.clj
+++ b/src/vault/client/api_util.clj
@@ -18,16 +18,15 @@
 (defmacro support-not-found
   "Tries to perform the api call, and if a 404 occurs, looks for :not-found in on-fail-opts"
   [vault-api-call on-fail-opts]
-  (let [fail-map (gensym 'api-options)]
-    `(try
-       ~vault-api-call
-       (catch ExceptionInfo ex#
-         (let [~fail-map ~on-fail-opts]
-           (if (and (contains? ~fail-map :not-found)
-                    (= ::api-error (:type (ex-data ex#)))
-                    (= 404 (:status (ex-data ex#))))
-             (:not-found ~fail-map)
-             (throw ex#)))))))
+  `(try
+     ~vault-api-call
+     (catch ExceptionInfo ex#
+       (let [api-fail-options# ~on-fail-opts]
+         (if (and (contains? api-fail-options# :not-found)
+                  (= ::api-error (:type (ex-data ex#)))
+                  (= 404 (:status (ex-data ex#))))
+           (:not-found api-fail-options#)
+           (throw ex#))))))
 
 
 (defn ^:no-doc kebabify-keys

--- a/src/vault/client/api_util.clj
+++ b/src/vault/client/api_util.clj
@@ -15,11 +15,12 @@
 
 ;; ## API Utilities
 
-(defmacro support-not-found
-  "Tries to perform the api call, and if a 404 occurs, looks for :not-found in on-fail-opts"
-  [vault-api-call on-fail-opts]
+(defmacro supports-not-found
+  "Tries to perform the body, which likely includes an API call. If a `404` `::api-error` occurs, looks for and returns
+  the value of `:not-found` in `on-fail-opts` if present"
+  [on-fail-opts & body]
   `(try
-     ~vault-api-call
+     ~@body
      (catch ExceptionInfo ex#
        (let [api-fail-options# ~on-fail-opts]
          (if (and (contains? api-fail-options# :not-found)

--- a/src/vault/client/http.clj
+++ b/src/vault/client/http.clj
@@ -244,7 +244,7 @@
                               (lease/lookup leases path))]
           (when-not (lease/expired? lease)
             (:data lease)))
-        (api-util/supports-not-found
+        (api-util/support-not-found
           (let [response (api-util/api-request this :get path {})
                 info (assoc (api-util/clean-body response)
                             :path path

--- a/src/vault/client/http.clj
+++ b/src/vault/client/http.clj
@@ -244,7 +244,8 @@
                               (lease/lookup leases path))]
           (when-not (lease/expired? lease)
             (:data lease)))
-        (api-util/support-not-found
+        (api-util/supports-not-found
+          opts
           (let [response (api-util/api-request this :get path {})
                 info (assoc (api-util/clean-body response)
                             :path path
@@ -255,8 +256,7 @@
                         path (:lease-duration info))
             (lease/update! leases info)
 
-            (:data info))
-          opts)))
+            (:data info)))))
 
 
   (write-secret!

--- a/src/vault/client/http.clj
+++ b/src/vault/client/http.clj
@@ -4,8 +4,8 @@
     [clojure.string :as str]
     [clojure.tools.logging :as log]
     [com.stuartsierra.component :as component]
-    [vault.client.api-util :as api-util]
     [vault.authenticate :as authenticate]
+    [vault.client.api-util :as api-util]
     [vault.core :as vault]
     [vault.lease :as lease]
     [vault.timer :as timer])
@@ -244,7 +244,7 @@
                               (lease/lookup leases path))]
           (when-not (lease/expired? lease)
             (:data lease)))
-        (try
+        (api-util/supports-not-found
           (let [response (api-util/api-request this :get path {})
                 info (assoc (api-util/clean-body response)
                             :path path
@@ -256,12 +256,7 @@
             (lease/update! leases info)
 
             (:data info))
-          (catch ExceptionInfo ex
-            (if (and (contains? opts :not-found)
-                     (= ::api-util/api-error (:type (ex-data ex)))
-                     (= 404 (:status (ex-data ex))))
-              (:not-found opts)
-              (throw ex))))))
+          opts)))
 
 
   (write-secret!

--- a/src/vault/client/mock.clj
+++ b/src/vault/client/mock.clj
@@ -4,6 +4,7 @@
     [clojure.edn :as edn]
     [clojure.java.io :as io]
     [clojure.string :as str]
+    [vault.client.api-util :as api-util]
     [vault.core :as vault])
   (:import
     java.net.URI
@@ -189,7 +190,9 @@
         (if (contains? opts :not-found)
           (:not-found opts)
           (throw (ex-info (str "No such secret: " path)
-                          {:secret path})))))
+                          {:secret path
+                           :type ::api-util/api-error
+                           :status 404})))))
 
 
   (write-secret!

--- a/src/vault/secrets/kvv2.clj
+++ b/src/vault/secrets/kvv2.clj
@@ -26,9 +26,9 @@
   - `:force-read`, `boolean`
     Force the secret to be read from the server even if there is a valid lease cached."
   ([client mount path opts]
-   (api-util/support-not-found
-     (:data (vault/read-secret client (str mount "/data/" path) (dissoc opts :not-found)))
-     opts))
+   (api-util/supports-not-found
+     opts
+     (:data (vault/read-secret client (str mount "/data/" path) (dissoc opts :not-found)))))
   ([client mount path]
    (read-secret client mount path nil)))
 
@@ -89,9 +89,7 @@
   - `path`: `String`, the path in vault of the secret you wish to read metadata for
   - `opts`: `map`, options to affect the read call, see `vault.core/read-secret` for more details"
   ([client mount path opts]
-   (api-util/support-not-found
-     (vault/read-secret client (str mount "/metadata/" path) (dissoc opts :not-found))
-     opts))
+   (vault/read-secret client (str mount "/metadata/" path) opts))
   ([client mount path]
    (read-metadata client mount path nil)))
 

--- a/src/vault/secrets/kvv2.clj
+++ b/src/vault/secrets/kvv2.clj
@@ -132,3 +132,14 @@
      (vault/write-secret! client (str mount "/delete/" path) {:versions versions})))
   ([client mount path]
    (delete-secret! client mount path nil)))
+
+
+(defn delete-metadata!
+  "Permanently deletes the key metadata and all version data for the specified key.
+  All version history will be removed. This cannot be undone. A boolean indicating deletion success is returned.
+
+  - `client`: `vault.client`, A client that handles vault auth, leases, and basic CRUD ops
+  - `mount`: `String`, the Vault secret mount (the part of the path which determines which secret engine is used)
+  - `path`: `String`, the path aligned to the secret you wish to delete all data for"
+  [client mount path]
+  (vault/delete-secret! client (str mount "/metadata/" path)))

--- a/src/vault/secrets/kvv2.clj
+++ b/src/vault/secrets/kvv2.clj
@@ -85,7 +85,8 @@
 
   Params:
   - `client`: `vault.client`, A client that handles vault auth, leases, and basic CRUD ops
-  - `path`: `String`, the path in vault of the secret you wish to read
+  - `mount`: `String`, the secret engine mount point you wish to read secret metadata in
+  - `path`: `String`, the path in vault of the secret you wish to read metadata for
   - `opts`: `map`, options to affect the read call, see `vault.core/read-secret` for more details"
   ([client mount path opts]
    (api-util/support-not-found
@@ -93,6 +94,28 @@
      opts))
   ([client mount path]
    (read-metadata client mount path nil)))
+
+
+(defn write-metadata!
+  "Creates a new version of a secret at the specified location. If the value does not yet exist, the calling token
+  must have an ACL policy granting the create capability. If the value already exists, the calling token must have an
+  ACL policy granting the update capability. Returns a boolean indicating whether the write was successful.
+
+  Params:
+  - `client`: `vault.client`, A client that handles vault auth, leases, and basic CRUD ops
+  - `mount`: `String`, the secret engine mount point you wish to write secret metadata in
+  - `path`: `String`, the path in vault of the secret you wish to write metadata for'
+  - `metadata`: `map` the metadata you wish to write.
+
+  Metadata options are:
+  -`:max_versions`: `int`, The number of versions to keep per key. This value applies to all keys, but a key's
+  metadata setting can overwrite this value. Once a key has more than the configured allowed versions the oldest
+  version will be permanently deleted. Defaults to 10.
+  -`:cas_required`: `boolean`, – If true all keys will require the cas parameter to be set on all write requests.
+  - :delete_version_after` `String` – If set, specifies the length of time before a version is deleted.
+  Accepts Go duration format string."
+  [client mount path metadata]
+  (vault/write-secret! client (str mount "/metadata/" path) metadata))
 
 
 (defn delete-secret!

--- a/src/vault/secrets/kvv2.clj
+++ b/src/vault/secrets/kvv2.clj
@@ -26,7 +26,7 @@
   - `:force-read`, `boolean`
     Force the secret to be read from the server even if there is a valid lease cached."
   ([client mount path opts]
-   (api-util/supports-not-found
+   (api-util/support-not-found
      (:data (vault/read-secret client (str mount "/data/" path) (dissoc opts :not-found)))
      opts))
   ([client mount path]
@@ -88,7 +88,7 @@
   - `path`: `String`, the path in vault of the secret you wish to read
   - `opts`: `map`, options to affect the read call, see `vault.core/read-secret` for more details"
   ([client mount path opts]
-   (api-util/supports-not-found
+   (api-util/support-not-found
      (vault/read-secret client (str mount "/metadata/" path) (dissoc opts :not-found))
      opts))
   ([client mount path]

--- a/test/vault/client/http_test.clj
+++ b/test/vault/client/http_test.clj
@@ -1,8 +1,8 @@
 (ns vault.client.http-test
   (:require
     [clojure.test :refer :all]
-    [vault.client.api-util :as api-util]
     [vault.authenticate :as authenticate]
+    [vault.client.api-util :as api-util]
     [vault.client.http :refer [http-client]]
     [vault.core :as vault]
     [vault.secrets.kvv1 :as vault-kvv1]))

--- a/test/vault/secrets/kvv2_test.clj
+++ b/test/vault/secrets/kvv2_test.clj
@@ -185,6 +185,51 @@
             (is (false? (vault-kvv2/delete-secret! client mount path-passed-in [123])))))))))
 
 
+(deftest read-metadata
+  (let [data {:data
+              {:created_time    "2018-03-22T02:24:06.945319214Z"
+               :current_version 3
+               :max_versions    0
+               :oldest_version  0
+               :updated_time    "2018-03-22T02:36:43.986212308Z"
+               :versions        {:1 {:created_time  "2018-03-22T02:24:06.945319214Z"
+                                     :deletion_time ""
+                                     :destroyed     false}
+                                 :2 {:created_time  "2018-03-22T02:36:33.954880664Z"
+                                     :deletion_time ""
+                                     :destroyed     false}
+                                 :3 {:created_time  "2018-03-22T02:36:43.986212308Z"
+                                     :deletion_time ""
+                                     :destroyed     false}}}}
+        mount "mount"
+        path-passed-in "path/passed/in"
+        token-passed-in "fake-token"
+        vault-url "https://vault.example.amperity.com"
+        client (http-client/http-client vault-url)]
+    (vault/authenticate! client :token token-passed-in)
+    (testing "Sends correct request and responds correctly upon success"
+      (with-redefs
+        [clj-http.client/request
+         (fn [req]
+           (is (= :get (:method req)))
+           (is (= (str vault-url "/v1/" mount "/metadata/" path-passed-in) (:url req)))
+           (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
+           {:body   data
+            :status 200})]
+        (is (= (:data data) (vault-kvv2/read-metadata client mount path-passed-in)))))
+    (testing "Sends correct request and responds correctly when metadata not found"
+      (with-redefs
+        [clj-http.client/request
+         (fn [req]
+           (is (= :get (:method req)))
+           (is (= (str vault-url "/v1/" mount "/metadata/" path-passed-in) (:url req)))
+           (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
+           (throw (ex-info "not found" {:errors [] :status 404 :type :vault.client.api-util/api-error})))]
+        (is (thrown? ExceptionInfo (vault-kvv2/read-metadata client mount path-passed-in {:force-read true})))
+        (is (= 3 (vault-kvv2/read-metadata client mount path-passed-in {:not-found  3
+                                                                        :force-read true})))))))
+
+
 ;; -------- Mock Client -------------------------------------------------------
 
 (defn mock-client-kvv2
@@ -222,6 +267,22 @@
             (vault-kvv2/read-config client "mount")))
       (is (true? (vault-kvv2/write-config! client "mount" config)))
       (is (= config (vault-kvv2/read-config client "mount")))))
+  (testing "Mock client can write and read metadata"
+    (let [client (mock-client-kvv2)]
+      (is (thrown? ExceptionInfo
+            (vault-kvv2/read-metadata client "mount" "doesn't exist" {:force-read true})))
+      (is (= {:data
+              {:created_time    "2018-03-22T02:24:06.945319214Z"
+               :current_version 1
+               :max_versions    0
+               :oldest_version  0
+               :updated_time    "2018-03-22T02:36:43.986212308Z"
+               :versions        {:1 {:created_time  "2018-03-22T02:24:06.945319214Z"
+                                     :deletion_time ""
+                                     :destroyed     false}}}}
+             (vault-kvv2/read-metadata client "mount" "identities" {:force-read true})))
+      (is (= 5 (vault-kvv2/read-metadata client "mount" "doesn't exist" {:force-read true
+                                                                         :not-found 5})))))
   (testing "Mock client returns true if path is found on delete for secret, false if not when no versions specified"
     (let [client (mock-client-kvv2)]
       (is (true? (vault-kvv2/delete-secret! client "mount" "identities")))

--- a/test/vault/secrets/secret-fixture-kvv2.edn
+++ b/test/vault/secrets/secret-fixture-kvv2.edn
@@ -1,3 +1,13 @@
 {"mount/data/identities"
  {:data {:batman         "Bruce Wayne"
-         :captain-marvel "Carol Danvers"}}}
+         :captain-marvel "Carol Danvers"}}
+ "mount/metadata/identities"
+ {:data
+  {:created_time    "2018-03-22T02:24:06.945319214Z"
+   :current_version 1
+   :max_versions    0
+   :oldest_version  0
+   :updated_time    "2018-03-22T02:36:43.986212308Z"
+   :versions        {:1 {:created_time  "2018-03-22T02:24:06.945319214Z"
+                         :deletion_time ""
+                         :destroyed     false}}}}}

--- a/test/vault/secrets/secret-fixture-kvv2.edn
+++ b/test/vault/secrets/secret-fixture-kvv2.edn
@@ -2,7 +2,6 @@
  {:data {:batman         "Bruce Wayne"
          :captain-marvel "Carol Danvers"}}
  "mount/metadata/identities"
- {:data
   {:created_time    "2018-03-22T02:24:06.945319214Z"
    :current_version 1
    :max_versions    0
@@ -10,4 +9,4 @@
    :updated_time    "2018-03-22T02:36:43.986212308Z"
    :versions        {:1 {:created_time  "2018-03-22T02:24:06.945319214Z"
                          :deletion_time ""
-                         :destroyed     false}}}}}
+                         :destroyed     false}}}}


### PR DESCRIPTION
Related to #39 

Exposes read, create/update, and delete API endpoints for KV V2 metadata (which holds info about all the secret versioning and secret specific configurations).

Also introduces a macro to help deal with repetition in API error handling for secret engine read functions.