### PR TITLE
consider expired, rotatable leases rotatable

### DIFF
--- a/src/vault/lease.clj
+++ b/src/vault/lease.clj
@@ -153,7 +153,10 @@
   [store window]
   (->> (list-leases store)
        (filter ::rotate)
-       (remove renewable?)
+       (filter (fn non-renewable?
+                 [lease]
+                 (or (expired? lease)
+                     (not (renewable? lease)))))
        (filter #(expires-within? % window))))
 
 

--- a/test/vault/client/http_test.clj
+++ b/test/vault/client/http_test.clj
@@ -1,8 +1,8 @@
 (ns vault.client.http-test
   (:require
     [clojure.test :refer :all]
-    [vault.client.api-util :as api-util]
     [vault.authenticate :as authenticate]
+    [vault.client.api-util :as api-util]
     [vault.client.http :refer [http-client]]
     [vault.core :as vault]
     [vault.secrets.kvv1 :as vault-kvv1]))

--- a/test/vault/secrets/kvv1_test.clj
+++ b/test/vault/secrets/kvv1_test.clj
@@ -123,7 +123,7 @@
          (fn [req]
            (is (= :delete (:method req)))
            (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
-           (is (= (str vault-url "/v1/" path-passed-in (:url req))))
+           (is (= (str vault-url "/v1/" path-passed-in) (:url req)))
            {:status 204})]
         (is (true? (vault/delete-secret! client path-passed-in)))))
     (testing "Delete secret returns correctly upon failure, and sends correct request"
@@ -132,7 +132,7 @@
          (fn [req]
            (is (= :delete (:method req)))
            (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
-           (is (= (str vault-url "/v1/" path-passed-in (:url req))))
+           (is (= (str vault-url "/v1/" path-passed-in) (:url req)))
            {:status 404})]
         (is (false? (vault/delete-secret! client path-passed-in)))))))
 


### PR DESCRIPTION
This helps mitigate secret expiration (outside the control
of the client such as in a network outage) that would otherwise
be rotatable. before this change, a lease wasn't marked
'renewable false' during the run of manage-leases so it
would just be swept. instead, this at least attempts to
rotate first before sweeping it for being expired.