### PR TITLE
KV-V2 List Secrets

### DIFF
--- a/src/vault/client/mock.clj
+++ b/src/vault/client/mock.clj
@@ -181,7 +181,10 @@
 
   (list-secrets
     [this path]
-    (filter #(str/starts-with? % (str path)) (keys @memory)))
+    (->> (keys @memory)
+         (filter #(str/starts-with? % (str path)))
+         ;; TODO: Mock here relies on string replace to get correct result for kvv2, this is brittle and not extensible
+         (map #(str/replace % #"(?:\w+\/)+metadata\/" ""))))
 
 
   (read-secret


### PR DESCRIPTION
Resolves #39 by exposing the kv-v2 list secrets endpoint. Works with mocking too.

I left a TODO in the mock client, but I think this is ready for review anyway. The issue can be addressed later in a minor version release