### PR TITLE
Support aws IAM authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ pom.xml.asc
 *.class
 /.lein-*
 /.nrepl-port
+.idea/
+*.iml

--- a/src/vault/authenticate.clj
+++ b/src/vault/authenticate.clj
@@ -14,10 +14,10 @@
   (let [auth-info (lease/auth-lease (:auth (api-util/clean-body response)))]
     (when-not (:client-token auth-info)
       (throw (ex-info (str "No client token returned from non-error API response: "
-                        (:status response) " " (:reason-phrase response))
-               {:body (:body response)})))
+                           (:status response) " " (:reason-phrase response))
+                      {:body (:body response)})))
     (log/info "Successfully authenticated to Vault as %s for policies: %s"
-      claim (str/join ", " (:policies auth-info)))
+              claim (str/join ", " (:policies auth-info)))
     (reset! auth-ref auth-info)))
 
 
@@ -31,7 +31,7 @@
 (defmethod authenticate* :default
   [_ auth-type _]
   (throw (ex-info (str "Unsupported auth-type " (pr-str auth-type))
-           {:auth-type auth-type})))
+                  {:auth-type auth-type})))
 
 
 (defmethod authenticate* :token
@@ -59,10 +59,10 @@
         :post (str (:api-url client) "/v1/auth/userpass/" (:auth-mount-point client) "login/" username)
         (merge
           (:http-opts client)
-          {:form-params  {:password password}
+          {:form-params {:password password}
            :content-type :json
-           :accept       :json
-           :as           :json})))))
+           :accept :json
+           :as :json})))))
 
 
 (defmethod authenticate* :app-id
@@ -75,10 +75,10 @@
         :post (str (:api-url client) "/v1/auth/app-id/" (:auth-mount-point client) "login")
         (merge
           (:http-opts client)
-          {:form-params  {:app_id app, :user_id user}
+          {:form-params {:app_id app, :user_id user}
            :content-type :json
-           :accept       :json
-           :as           :json})))))
+           :accept :json
+           :as :json})))))
 
 
 (defmethod authenticate* :app-role
@@ -91,10 +91,10 @@
         :post (str (:api-url client) "/v1/auth/approle/" (:auth-mount-point client) "login")
         (merge
           (:http-opts client)
-          {:form-params  {:role_id role-id, :secret_id secret-id}
+          {:form-params {:role_id role-id, :secret_id secret-id}
            :content-type :json
-           :accept       :json
-           :as           :json})))))
+           :accept :json
+           :as :json})))))
 
 
 (defmethod authenticate* :ldap
@@ -107,10 +107,10 @@
         :post (str (:api-url client) "/v1/auth/ldap/" (:auth-mount-point client) "login/" username)
         (merge
           (:http-opts client)
-          {:form-params  {:password password}
+          {:form-params {:password password}
            :content-type :json
-           :accept       :json
-           :as           :json})))))
+           :accept :json
+           :as :json})))))
 
 
 (defmethod authenticate* :k8s
@@ -128,10 +128,10 @@
         :post (str (:api-url client) api-path)
         (merge
           (:http-opts client)
-          {:form-params  {:jwt jwt :role role}
+          {:form-params {:jwt jwt :role role}
            :content-type :json
-           :accept       :json
-           :as           :json})))))
+           :accept :json
+           :as :json})))))
 
 
 (defmethod authenticate* :aws-iam
@@ -156,11 +156,11 @@
         :post (str (:api-url client) api-path)
         (merge
           (:http-opts client)
-          {:form-params  {:iam_http_request_method http-request-method
-                          :iam_request_url         request-url
-                          :iam_request_body        request-body
-                          :iam_request_headers     request-headers
-                          :role                    role}
+          {:form-params {:iam_http_request_method http-request-method
+                         :iam_request_url request-url
+                         :iam_request_body request-body
+                         :iam_request_headers request-headers
+                         :role role}
            :content-type :json
-           :accept       :json
-           :as           :json})))))
+           :accept :json
+           :as :json})))))

--- a/src/vault/authenticate.clj
+++ b/src/vault/authenticate.clj
@@ -14,10 +14,10 @@
   (let [auth-info (lease/auth-lease (:auth (api-util/clean-body response)))]
     (when-not (:client-token auth-info)
       (throw (ex-info (str "No client token returned from non-error API response: "
-                           (:status response) " " (:reason-phrase response))
-                      {:body (:body response)})))
+                        (:status response) " " (:reason-phrase response))
+               {:body (:body response)})))
     (log/info "Successfully authenticated to Vault as %s for policies: %s"
-              claim (str/join ", " (:policies auth-info)))
+      claim (str/join ", " (:policies auth-info)))
     (reset! auth-ref auth-info)))
 
 
@@ -31,7 +31,7 @@
 (defmethod authenticate* :default
   [_ auth-type _]
   (throw (ex-info (str "Unsupported auth-type " (pr-str auth-type))
-                  {:auth-type auth-type})))
+           {:auth-type auth-type})))
 
 
 (defmethod authenticate* :token
@@ -59,10 +59,10 @@
         :post (str (:api-url client) "/v1/auth/userpass/" (:auth-mount-point client) "login/" username)
         (merge
           (:http-opts client)
-          {:form-params {:password password}
+          {:form-params  {:password password}
            :content-type :json
-           :accept :json
-           :as :json})))))
+           :accept       :json
+           :as           :json})))))
 
 
 (defmethod authenticate* :app-id
@@ -75,10 +75,10 @@
         :post (str (:api-url client) "/v1/auth/app-id/" (:auth-mount-point client) "login")
         (merge
           (:http-opts client)
-          {:form-params {:app_id app, :user_id user}
+          {:form-params  {:app_id app, :user_id user}
            :content-type :json
-           :accept :json
-           :as :json})))))
+           :accept       :json
+           :as           :json})))))
 
 
 (defmethod authenticate* :app-role
@@ -91,10 +91,10 @@
         :post (str (:api-url client) "/v1/auth/approle/" (:auth-mount-point client) "login")
         (merge
           (:http-opts client)
-          {:form-params {:role_id role-id, :secret_id secret-id}
+          {:form-params  {:role_id role-id, :secret_id secret-id}
            :content-type :json
-           :accept :json
-           :as :json})))))
+           :accept       :json
+           :as           :json})))))
 
 
 (defmethod authenticate* :ldap
@@ -107,10 +107,10 @@
         :post (str (:api-url client) "/v1/auth/ldap/" (:auth-mount-point client) "login/" username)
         (merge
           (:http-opts client)
-          {:form-params {:password password}
+          {:form-params  {:password password}
            :content-type :json
-           :accept :json
-           :as :json})))))
+           :accept       :json
+           :as           :json})))))
 
 
 (defmethod authenticate* :k8s
@@ -128,25 +128,25 @@
         :post (str (:api-url client) api-path)
         (merge
           (:http-opts client)
-          {:form-params {:jwt jwt :role role}
+          {:form-params  {:jwt jwt :role role}
            :content-type :json
-           :accept :json
-           :as :json})))))
+           :accept       :json
+           :as           :json})))))
 
 
-(defmethod authenticate* :aws
+(defmethod authenticate* :aws-iam
   [client _ credentials]
-  (let [{:keys [api-path iam-http-request-method iam-request-url iam-request-body
-                iam-request-headers role]} credentials
+  (let [{:keys [api-path http-request-method request-url request-body request-headers
+                role]} credentials
         api-path (or api-path (str "/v1/auth/aws/" (:auth-mount-point client) "login"))]
-    (when-not iam-http-request-method
-      (throw (IllegalArgumentException. "AWS auth credentials must include :iam-http-request-method")))
-    (when-not iam-request-url
-      (throw (IllegalArgumentException. "AWS auth credentials must include :iam-request-url")))
-    (when-not iam-request-body
-      (throw (IllegalArgumentException. "AWS auth credentials must include :iam-request-body")))
-    (when-not iam-request-headers
-      (throw (IllegalArgumentException. "AWS auth credentials must include :iam-request-headers")))
+    (when-not http-request-method
+      (throw (IllegalArgumentException. "AWS auth credentials must include :http-request-method")))
+    (when-not request-url
+      (throw (IllegalArgumentException. "AWS auth credentials must include :request-url")))
+    (when-not request-body
+      (throw (IllegalArgumentException. "AWS auth credentials must include :request-body")))
+    (when-not request-headers
+      (throw (IllegalArgumentException. "AWS auth credentials must include :request-headers")))
     (when-not role
       (throw (IllegalArgumentException. "AWS auth credentials must include :role")))
     (api-auth!
@@ -156,11 +156,11 @@
         :post (str (:api-url client) api-path)
         (merge
           (:http-opts client)
-          {:form-params  {:iam_http_request_method iam-http-request-method
-                          :iam_request_url iam-request-url
-                          :iam_request_body iam-request-body
-                          :iam_request_headers iam-request-headers
-                          :role role}
+          {:form-params  {:iam_http_request_method http-request-method
+                          :iam_request_url         request-url
+                          :iam_request_body        request-body
+                          :iam_request_headers     request-headers
+                          :role                    role}
            :content-type :json
            :accept       :json
            :as           :json})))))

--- a/src/vault/client/http.clj
+++ b/src/vault/client/http.clj
@@ -144,8 +144,8 @@
 
   (revoke-token!
     [this]
-    (when-let [token (:client-token @auth)]
-      (.revoke-token! this token)))
+    (let [response (api-util/api-request this :post "auth/token/revoke-self" {})]
+      (= 204 (:status response))))
 
 
   (revoke-token!

--- a/src/vault/core.clj
+++ b/src/vault/core.clj
@@ -21,7 +21,7 @@
     - `:k8s {:jwt \"...\", :role \"...\"}`
     - `:app-id {:app \"foo-service-dev\", :user \"...\"}`
     - `:app-role {:role-id \"...\", :secret-id \"...\"}
-    - `:aws {:iam-http-request-method \"...\", iam-request-url \"...\", iam-request-body \"...\", iam-request-headers \"...\", :role \"...\"}`")
+    - `:aws-iam {:http-request-method \"...\", :request-url \"...\", :request-body \"...\", :request-headers \"...\", :role \"...\"}`")
 
   (status
     [client]

--- a/src/vault/core.clj
+++ b/src/vault/core.clj
@@ -20,7 +20,8 @@
     - `:ldap {:username \"LDAP username\", :password \"hunter2\"}`
     - `:k8s {:jwt \"...\", :role \"...\"}`
     - `:app-id {:app \"foo-service-dev\", :user \"...\"}`
-    - `:app-role {:role-id \"...\", :secret-id \"...\"}")
+    - `:app-role {:role-id \"...\", :secret-id \"...\"}
+    - `:aws {:iam-http-request-method \"...\", iam-request-url \"...\", iam-request-body \"...\", iam-request-headers \"...\", :role \"...\"}`")
 
   (status
     [client]

--- a/test/vault/client/http_test.clj
+++ b/test/vault/client/http_test.clj
@@ -119,7 +119,7 @@
                   :accept :json
                   :as :json}]]
                @api-requests))
-        (is (= [[(str "AWS auth role=my-role")
+        (is (= [["AWS auth role=my-role"
                  (:auth client)
                  :do-api-request-response]]
                @api-auths)))))

--- a/test/vault/client/http_test.clj
+++ b/test/vault/client/http_test.clj
@@ -103,7 +103,7 @@
                     authenticate/api-auth! (fn [& args]
                                              (swap! api-auths conj args)
                                              :api-auth!-response)]
-        (vault/authenticate! client :aws {:role "my-role"
+        (vault/authenticate! client :aws-iam {:role "my-role"
                                           :iam-http-request-method "POST"
                                           :iam-request-url "fake.sts.com"
                                           :iam-request-body "FakeAction&Version=1"
@@ -132,7 +132,7 @@
                     authenticate/api-auth! (fn [& args]
                                              (swap! api-auths conj args))]
         (is (thrown? IllegalArgumentException
-              (vault/authenticate! client :aws {:role "my-role"
+              (vault/authenticate! client :aws-iam {:role "my-role"
                                                 :iam-request-url "fake.sts.com"
                                                 :iam-request-body "FakeAction&Version=1"
                                                 :iam-request-headers "{'foo':'bar'}"})))
@@ -147,7 +147,7 @@
                     authenticate/api-auth! (fn [& args]
                                              (swap! api-auths conj args))]
         (is (thrown? IllegalArgumentException
-              (vault/authenticate! client :aws {:role "my-role"
+              (vault/authenticate! client :aws-iam {:role "my-role"
                                                 :iam-http-request-method "POST"
                                                 :iam-request-body "FakeAction&Version=1"
                                                 :iam-request-headers "{'foo':'bar'}"})))
@@ -162,7 +162,7 @@
                     authenticate/api-auth! (fn [& args]
                                              (swap! api-auths conj args))]
         (is (thrown? IllegalArgumentException
-              (vault/authenticate! client :aws {:role "my-role"
+              (vault/authenticate! client :aws-iam {:role "my-role"
                                                 :iam-http-request-method "POST"
                                                 :iam-request-url "fake.sts.com"
                                                 :iam-request-headers "{'foo':'bar'}"})))
@@ -177,7 +177,7 @@
                     authenticate/api-auth! (fn [& args]
                                              (swap! api-auths conj args))]
         (is (thrown? IllegalArgumentException
-              (vault/authenticate! client :aws {:role "my-role"
+              (vault/authenticate! client :aws-iam {:role "my-role"
                                                 :iam-http-request-method "POST"
                                                 :iam-request-url "fake.sts.com"
                                                 :iam-request-body "FakeAction&Version=1"})))
@@ -192,7 +192,7 @@
                     authenticate/api-auth! (fn [& args]
                                              (swap! api-auths conj args))]
         (is (thrown? IllegalArgumentException
-              (vault/authenticate! client :aws {:iam-http-request-method "POST"
+              (vault/authenticate! client :aws-iam {:iam-http-request-method "POST"
                                                 :iam-request-url "fake.sts.com"
                                                 :iam-request-body "FakeAction&Version=1"
                                                 :iam-request-headers "{'foo':'bar'}"})))

--- a/test/vault/client/http_test.clj
+++ b/test/vault/client/http_test.clj
@@ -104,10 +104,10 @@
                                              (swap! api-auths conj args)
                                              :api-auth!-response)]
         (vault/authenticate! client :aws-iam {:role "my-role"
-                                          :iam-http-request-method "POST"
-                                          :iam-request-url "fake.sts.com"
-                                          :iam-request-body "FakeAction&Version=1"
-                                          :iam-request-headers "{'foo':'bar'}"})
+                                              :http-request-method "POST"
+                                              :request-url "fake.sts.com"
+                                              :request-body "FakeAction&Version=1"
+                                              :request-headers "{'foo':'bar'}"})
         (is (= [[:post
                  (str example-url "/v1/auth/aws/login")
                  {:form-params {:iam_http_request_method "POST"
@@ -123,7 +123,7 @@
                  (:auth client)
                  :do-api-request-response]]
                @api-auths)))))
-  (testing "When no iam-http-request-method is specified"
+  (testing "When no http-request-method is specified"
     (let [client (http-client example-url)
           api-requests (atom [])
           api-auths (atom [])]
@@ -133,12 +133,12 @@
                                              (swap! api-auths conj args))]
         (is (thrown? IllegalArgumentException
               (vault/authenticate! client :aws-iam {:role "my-role"
-                                                :iam-request-url "fake.sts.com"
-                                                :iam-request-body "FakeAction&Version=1"
-                                                :iam-request-headers "{'foo':'bar'}"})))
+                                                    :request-url "fake.sts.com"
+                                                    :request-body "FakeAction&Version=1"
+                                                    :request-headers "{'foo':'bar'}"})))
         (is (empty? @api-requests))
         (is (empty? @api-auths)))))
-  (testing "When no iam-request-url is specified"
+  (testing "When no request-url is specified"
     (let [client (http-client example-url)
           api-requests (atom [])
           api-auths (atom [])]
@@ -148,12 +148,12 @@
                                              (swap! api-auths conj args))]
         (is (thrown? IllegalArgumentException
               (vault/authenticate! client :aws-iam {:role "my-role"
-                                                :iam-http-request-method "POST"
-                                                :iam-request-body "FakeAction&Version=1"
-                                                :iam-request-headers "{'foo':'bar'}"})))
+                                                    :http-request-method "POST"
+                                                    :request-body "FakeAction&Version=1"
+                                                    :request-headers "{'foo':'bar'}"})))
         (is (empty? @api-requests))
         (is (empty? @api-auths)))))
-  (testing "When no iam-request-body is specified"
+  (testing "When no request-body is specified"
     (let [client (http-client example-url)
           api-requests (atom [])
           api-auths (atom [])]
@@ -163,12 +163,12 @@
                                              (swap! api-auths conj args))]
         (is (thrown? IllegalArgumentException
               (vault/authenticate! client :aws-iam {:role "my-role"
-                                                :iam-http-request-method "POST"
-                                                :iam-request-url "fake.sts.com"
-                                                :iam-request-headers "{'foo':'bar'}"})))
+                                                    :http-request-method "POST"
+                                                    :request-url "fake.sts.com"
+                                                    :request-headers "{'foo':'bar'}"})))
         (is (empty? @api-requests))
         (is (empty? @api-auths)))))
-  (testing "When no iam-request-headers is specified"
+  (testing "When no request-headers is specified"
     (let [client (http-client example-url)
           api-requests (atom [])
           api-auths (atom [])]
@@ -178,9 +178,9 @@
                                              (swap! api-auths conj args))]
         (is (thrown? IllegalArgumentException
               (vault/authenticate! client :aws-iam {:role "my-role"
-                                                :iam-http-request-method "POST"
-                                                :iam-request-url "fake.sts.com"
-                                                :iam-request-body "FakeAction&Version=1"})))
+                                                    :http-request-method "POST"
+                                                    :request-url "fake.sts.com"
+                                                    :request-body "FakeAction&Version=1"})))
         (is (empty? @api-requests))
         (is (empty? @api-auths)))))
   (testing "When no role is specified"
@@ -192,9 +192,9 @@
                     authenticate/api-auth! (fn [& args]
                                              (swap! api-auths conj args))]
         (is (thrown? IllegalArgumentException
-              (vault/authenticate! client :aws-iam {:iam-http-request-method "POST"
-                                                :iam-request-url "fake.sts.com"
-                                                :iam-request-body "FakeAction&Version=1"
-                                                :iam-request-headers "{'foo':'bar'}"})))
+              (vault/authenticate! client :aws-iam {:http-request-method "POST"
+                                                    :request-url "fake.sts.com"
+                                                    :request-body "FakeAction&Version=1"
+                                                    :request-headers "{'foo':'bar'}"})))
         (is (empty? @api-requests))
         (is (empty? @api-auths))))))


### PR DESCRIPTION
To sanity check on this vault does expect the iam payload values to be b64 encoded, at the moment I have left that to the consumer to understand as I didn't want to pull additional dependencies into the project. Let me know if you think that is worth changing.