### PR TITLE
#53 support babashka use httpkit + api updates fro vault 1.7.1 + deps.edn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ pom.xml.asc
 
 .calva
 .lsp
+.cpcache

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ pom.xml.asc
 /.nrepl-port
 .idea/
 *.iml
+
+.calva
+.lsp

--- a/bb.edn
+++ b/bb.edn
@@ -2,9 +2,7 @@
 ;; Type bb <task-name> or bb run <task-name> to run a task
 {:min-bb-version "0.4.0"
  :paths ["script"]
- :deps {;; amperity/vault-clj {:git/url "https://github.com/ieugen/vault-clj.git"
-        ;;                     :sha "3fe14779eae3ad8cc64cefb9ac7eb7e3eb2c5da2"}
-        amperity/vault-clj {:local/root "."}}
+ :deps {amperity/vault-clj {:local/root "."}}
  :tasks {:requires ([vault.core :as vault]
                     [vault.client.http]
                     [vault.secrets.kvv2 :as kvv2])

--- a/bb.edn
+++ b/bb.edn
@@ -2,20 +2,17 @@
 ;; Type bb <task-name> or bb run <task-name> to run a task
 {:min-bb-version "0.4.0"
  :paths ["script"]
- :deps {amperity/vault-clj {:git/url "https://github.com/ieugen/vault-clj.git"
-                            :sha "3fe14779eae3ad8cc64cefb9ac7eb7e3eb2c5da2"}
-        org.clojure/tools.logging {:mvn/version "1.1.0"}}
+ :deps {;; amperity/vault-clj {:git/url "https://github.com/ieugen/vault-clj.git"
+        ;;                     :sha "3fe14779eae3ad8cc64cefb9ac7eb7e3eb2c5da2"}
+        amperity/vault-clj {:local/root "."}}
  :tasks {:requires ([vault.core :as vault]
                     [vault.client.http]
-                    [clojure.tools.logging :as log])
-         :init     (do
-                     (def client (vault/new-client "https://vault.do.drevidence.com:8200")))
+                    [vault.secrets.kvv2 :as kvv2])
+         :init     (do)
          ;; Helpers
          vault-get-dev {:doc "Get dev secrets from vault - requires vault cli."
                         :task (do
-                                (client "secret/foo/bar"))}
-         log-me {:doc "Log test"
-                       :task (do
-                               (log/info "hello")
-                               (log/trace "hmm"))}}}
+                                (let [client (vault/new-client (System/getenv "VAULT_ADDR"))]
+                                  (vault/authenticate! client :token (System/getenv "VAULT_TOKEN"))
+                                  (println (kvv2/read-secret client "DocSearch" "stage/app"))))}}}
 

--- a/bb.edn
+++ b/bb.edn
@@ -1,0 +1,21 @@
+;; Type bb tasks to see all tasks
+;; Type bb <task-name> or bb run <task-name> to run a task
+{:min-bb-version "0.4.0"
+ :paths ["script"]
+ :deps {amperity/vault-clj {:git/url "https://github.com/ieugen/vault-clj.git"
+                            :sha "3fe14779eae3ad8cc64cefb9ac7eb7e3eb2c5da2"}
+        org.clojure/tools.logging {:mvn/version "1.1.0"}}
+ :tasks {:requires ([vault.core :as vault]
+                    [vault.client.http]
+                    [clojure.tools.logging :as log])
+         :init     (do
+                     (def client (vault/new-client "https://vault.do.drevidence.com:8200")))
+         ;; Helpers
+         vault-get-dev {:doc "Get dev secrets from vault - requires vault cli."
+                        :task (do
+                                (client "secret/foo/bar"))}
+         log-me {:doc "Log test"
+                       :task (do
+                               (log/info "hello")
+                               (log/trace "hmm"))}}}
+

--- a/deps.edn
+++ b/deps.edn
@@ -7,6 +7,7 @@
         com.stuartsierra/component {:mvn/version "1.0.0"}}
  :aliases {:dev
            {:extra-deps {commons-logging/commons-logging {:mvn/version "1.2"}
+                         org.clojure/tools.trace {:mvn/version "0.7.11"}
                          org.slf4j/slf4j-simple {:mvn/version "1.7.30"}}}
            :repl
            {:extra-paths ["dev"]

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,22 @@
+{:paths ["src"]
+ :deps {org.clojure/clojure {:mvn/version "1.10.1"}
+        org.clojure/tools.logging {:mvn/version "1.1.0"}
+        amperity/envoy {:mvn/version "0.3.3"}
+        cheshire/cheshire {:mvn/version "5.10.0"}
+        http-kit/http-kit {:mvn/version "2.5.3"}
+        com.stuartsierra/component {:mvn/version "1.0.0"}}
+ :aliases {:dev
+           {:extra-deps {commons-logging/commons-logging {:mvn/version "1.2"}
+                         org.slf4j/slf4j-simple {:mvn/version "1.7.30"}}}
+           :repl
+           {:extra-paths ["dev"]
+            :extra-deps {org.clojure/tools.namespace {:mvn/version "1.1.0"}}
+            :jvm-opts ["-Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.SimpleLog"
+                       "-Dorg.apache.commons.logging.simplelog.showdatetime=true"
+                       "-Dorg.apache.commons.logging.simplelog.defaultlog=info"
+                       "-Dorg.apache.commons.logging.simplelog.log.vault=debug"
+                       "-Dclojure.main.report=stderr"]}
+           :test
+           ;; TODO: add test deps and make test run :plugins [[lein-cloverage "1.2.1"]]
+           {:jvm-opts ["-Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.NoOpLog"
+                       "-Dclojure.main.report=stderr"]}}}

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,19 +1,19 @@
 (ns user
   (:require
-   [clojure.java.io :as io]
-   [clojure.repl :refer :all]
-   [clojure.tools.trace :as trace]
-   [clojure.string :as str]
-   [clojure.tools.namespace.repl :refer [refresh]]
-   [com.stuartsierra.component :as component]
-   [vault.client.http]
-   [vault.client.mock]
-   [vault.client.api-util]
-   [org.httpkit.client]
-   [vault.core :as vault]
-   [vault.secrets.kvv2 :as kvv2]
-   [vault.env :as venv]
-   [vault.lease :as lease]))
+    [clojure.java.io :as io]
+    [clojure.repl :refer :all]
+    [clojure.string :as str]
+    [clojure.tools.namespace.repl :refer [refresh]]
+    [clojure.tools.trace :as trace]
+    [com.stuartsierra.component :as component]
+    [org.httpkit.client]
+    [vault.client.api-util]
+    [vault.client.http]
+    [vault.client.mock]
+    [vault.core :as vault]
+    [vault.env :as venv]
+    [vault.lease :as lease]
+    [vault.secrets.kvv2 :as kvv2]))
 
 
 (def client nil)

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,15 +1,19 @@
 (ns user
   (:require
-    [clojure.java.io :as io]
-    [clojure.repl :refer :all]
-    [clojure.string :as str]
-    [clojure.tools.namespace.repl :refer [refresh]]
-    [com.stuartsierra.component :as component]
-    [vault.client.http]
-    [vault.client.mock]
-    [vault.core :as vault]
-    [vault.env :as venv]
-    [vault.lease :as lease]))
+   [clojure.java.io :as io]
+   [clojure.repl :refer :all]
+   [clojure.tools.trace :as trace]
+   [clojure.string :as str]
+   [clojure.tools.namespace.repl :refer [refresh]]
+   [com.stuartsierra.component :as component]
+   [vault.client.http]
+   [vault.client.mock]
+   [vault.client.api-util]
+   [org.httpkit.client]
+   [vault.core :as vault]
+   [vault.secrets.kvv2 :as kvv2]
+   [vault.env :as venv]
+   [vault.lease :as lease]))
 
 
 (def client nil)
@@ -34,3 +38,22 @@
     (when vault-token
       (vault/authenticate! vault-client :token vault-token))
     (alter-var-root #'client (constantly (component/start vault-client)))))
+
+
+(comment
+
+  (trace/trace-ns vault.client.http)
+  (trace/trace-ns vault.core)
+  (trace/trace-ns vault.client.api-util)
+  (trace/trace-ns vault.secrets.kvv2)
+  (trace/trace-ns org.httpkit.client)
+
+  ;; export VAULT_TOKEN="Token value"
+  (let [client (vault/new-client (System/getenv "VAULT_ADDR"))]
+    (vault/authenticate! client :token (System/getenv "VAULT_TOKEN"))
+    (kvv2/read-secret client "DocSearch" "stage/app"))
+
+  (System/getenv "VAULT_TOKEN")
+
+  0
+  )

--- a/project.clj
+++ b/project.clj
@@ -18,6 +18,7 @@
   :profiles
   {:dev
    {:dependencies [[commons-logging "1.2"]
+                   [org.clojure/tools.trace "0.7.11"]
                    [org.slf4j/slf4j-simple "1.7.30"]]}
 
    :repl

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
 
   :deploy-branches ["master"]
-  ;; :pedantic? :abort
+  :pedantic? :abort
 
   :dependencies
   [[org.clojure/clojure "1.10.1"]

--- a/project.clj
+++ b/project.clj
@@ -5,19 +5,20 @@
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
 
   :deploy-branches ["master"]
-  :pedantic? :abort
+  ;; :pedantic? :abort
 
   :dependencies
   [[org.clojure/clojure "1.10.1"]
    [org.clojure/tools.logging "1.1.0"]
    [amperity/envoy "0.3.3"]
    [cheshire "5.10.0"]
-   [clj-http "3.11.0"]
+   [http-kit "2.5.3"]
    [com.stuartsierra/component "1.0.0"]]
 
   :profiles
   {:dev
-   {:dependencies [[commons-logging "1.2"]]}
+   {:dependencies [[commons-logging "1.2"]
+                   [org.slf4j/slf4j-simple "1.7.30"]]}
 
    :repl
    {:source-paths ["dev"]
@@ -25,8 +26,10 @@
     :jvm-opts ["-Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.SimpleLog"
                "-Dorg.apache.commons.logging.simplelog.showdatetime=true"
                "-Dorg.apache.commons.logging.simplelog.defaultlog=info"
-               "-Dorg.apache.commons.logging.simplelog.log.vault=debug"]}
+               "-Dorg.apache.commons.logging.simplelog.log.vault=debug"
+               "-Dclojure.main.report=stderr"]}
 
    :test
    {:plugins [[lein-cloverage "1.2.1"]]
-    :jvm-opts ["-Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.NoOpLog"]}})
+    :jvm-opts ["-Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.NoOpLog"
+               "-Dclojure.main.report=stderr"]}})

--- a/src/vault/authenticate.clj
+++ b/src/vault/authenticate.clj
@@ -62,7 +62,7 @@
           {:form-params {:password password}
            :content-type :json
            :accept :json
-           :as :json})))))
+           })))))
 
 
 (defmethod authenticate* :app-id
@@ -78,7 +78,7 @@
           {:form-params {:app_id app, :user_id user}
            :content-type :json
            :accept :json
-           :as :json})))))
+           })))))
 
 
 (defmethod authenticate* :app-role
@@ -94,7 +94,7 @@
           {:form-params {:role_id role-id, :secret_id secret-id}
            :content-type :json
            :accept :json
-           :as :json})))))
+           })))))
 
 
 (defmethod authenticate* :ldap
@@ -110,7 +110,7 @@
           {:form-params {:password password}
            :content-type :json
            :accept :json
-           :as :json})))))
+           })))))
 
 
 (defmethod authenticate* :k8s
@@ -131,7 +131,7 @@
           {:form-params {:jwt jwt :role role}
            :content-type :json
            :accept :json
-           :as :json})))))
+           })))))
 
 
 (defmethod authenticate* :aws-iam
@@ -163,4 +163,4 @@
                          :role role}
            :content-type :json
            :accept :json
-           :as :json})))))
+           })))))

--- a/src/vault/authenticate.clj
+++ b/src/vault/authenticate.clj
@@ -61,8 +61,7 @@
           (:http-opts client)
           {:form-params {:password password}
            :content-type :json
-           :accept :json
-           })))))
+           :accept :json})))))
 
 
 (defmethod authenticate* :app-id
@@ -77,8 +76,7 @@
           (:http-opts client)
           {:form-params {:app_id app, :user_id user}
            :content-type :json
-           :accept :json
-           })))))
+           :accept :json})))))
 
 
 (defmethod authenticate* :app-role
@@ -93,8 +91,7 @@
           (:http-opts client)
           {:form-params {:role_id role-id, :secret_id secret-id}
            :content-type :json
-           :accept :json
-           })))))
+           :accept :json})))))
 
 
 (defmethod authenticate* :ldap
@@ -109,8 +106,7 @@
           (:http-opts client)
           {:form-params {:password password}
            :content-type :json
-           :accept :json
-           })))))
+           :accept :json})))))
 
 
 (defmethod authenticate* :k8s
@@ -130,8 +126,7 @@
           (:http-opts client)
           {:form-params {:jwt jwt :role role}
            :content-type :json
-           :accept :json
-           })))))
+           :accept :json})))))
 
 
 (defmethod authenticate* :aws-iam
@@ -162,5 +157,4 @@
                          :iam_request_headers request-headers
                          :role role}
            :content-type :json
-           :accept :json
-           })))))
+           :accept :json})))))

--- a/src/vault/client/api_util.clj
+++ b/src/vault/client/api_util.clj
@@ -1,10 +1,10 @@
 (ns vault.client.api-util
   (:require
-    [cheshire.core :as json]
-    [clj-http.client :as http]
-    [clojure.string :as str]
-    [clojure.tools.logging :as log]
-    [clojure.walk :as walk])
+   [cheshire.core :as json]
+   [org.httpkit.client :as http]
+   [clojure.string :as str]
+   [clojure.tools.logging :as log]
+   [clojure.walk :as walk])
   (:import
     (clojure.lang
       ExceptionInfo)

--- a/src/vault/client/api_util.clj
+++ b/src/vault/client/api_util.clj
@@ -1,15 +1,16 @@
 (ns vault.client.api-util
   (:require
-   [cheshire.core :as json]
-   [org.httpkit.client :as http]
-   [clojure.string :as str]
-   [clojure.tools.logging :as log]
-   [clojure.walk :as walk])
+    [cheshire.core :as json]
+    [clojure.string :as str]
+    [clojure.tools.logging :as log]
+    [clojure.walk :as walk]
+    [org.httpkit.client :as http])
   (:import
     (clojure.lang
       ExceptionInfo)
     (java.security
       MessageDigest)))
+
 
 ;; ## API Utilities
 
@@ -53,11 +54,13 @@
   [value]
   (keyword-swap-chars value "-" "_"))
 
+
 (defn ^String encode-hex-string
   "Encode an array of bytes to hex string."
   [^bytes bytes]
   (->> (map #(format "%02x" %) bytes)
        (apply str)))
+
 
 (defn ^:no-doc sha-256
   "Geerate a SHA-2 256 bit digest from a string."
@@ -74,9 +77,9 @@
   response to the original result to preserve accuracy."
   [response]
   (->
-   (:body response)
-   (json/parse-string true)
-   (kebabify-keys)))
+    (:body response)
+    (json/parse-string true)
+    (kebabify-keys)))
 
 
 (defn ^:no-doc api-error
@@ -127,16 +130,16 @@
   Currently always uses API version `v1`. The `path` should be relative to the
   version root."
   [client method path req]
-  ; Check API path.
+  ;; Check API path.
   (when-not (and (string? path) (not (str/blank? path)))
     (throw (IllegalArgumentException.
              (str "API path must be a non-empty string, got: "
                   (pr-str path)))))
-  ; Check client authentication.
+  ;; Check client authentication.
   (when-not (some-> client :auth deref :client-token)
     (throw (RuntimeException.
              "Cannot call API path with unauthenticated client.")))
-  ; Call API with standard arguments.
+  ;; Call API with standard arguments.
   (do-api-request
     method
     (str (:api-url client) "/v1/" path)

--- a/src/vault/client/api_util.clj
+++ b/src/vault/client/api_util.clj
@@ -132,12 +132,12 @@
   [client method path req]
   ;; Check API path.
   (when-not (and (string? path) (not (str/blank? path)))
-    (throw (IllegalArgumentException.
+    (throw (java.lang.IllegalArgumentException.
              (str "API path must be a non-empty string, got: "
                   (pr-str path)))))
   ;; Check client authentication.
   (when-not (some-> client :auth deref :client-token)
-    (throw (RuntimeException.
+    (throw (java.lang.IllegalStateException.
              "Cannot call API path with unauthenticated client.")))
   ;; Call API with standard arguments.
   (do-api-request
@@ -161,12 +161,3 @@
       {:headers {"X-Vault-Token" wrap-token}
        :content-type :json
        :accept :json})))
-
-
-(comment
-
-  (let [ba (byte-array (range 255))]
-    #_(Hex/encodeHexString ba)
-    (encode-hex-string ba))
-
-  0)

--- a/src/vault/client/http.clj
+++ b/src/vault/client/http.clj
@@ -78,8 +78,7 @@
     (-> (api-util/do-api-request
           :get (str api-url "/v1/sys/health")
           (assoc http-opts
-                 :accept :json
-                 :as :json))
+                 :accept :json))
         (api-util/clean-body)))
 
 

--- a/src/vault/client/http.clj
+++ b/src/vault/client/http.clj
@@ -32,9 +32,9 @@
   (start
     [this]
     (if lease-timer
-      ; Already running
+      ;; Already running
       this
-      ; Start lease heartbeat thread.
+      ;; Start lease heartbeat thread.
       (let [window (:lease-renewal-window this 300)
             period (:lease-check-period   this  60)
             jitter (:lease-check-jitter   this  10)
@@ -49,9 +49,9 @@
     [this]
     (if lease-timer
       (do
-        ; Stop lease timer thread.
+        ;; Stop lease timer thread.
         (timer/stop! lease-timer)
-        ; Revoke all outstanding leases.
+        ;; Revoke all outstanding leases.
         (when-let [outstanding (and (:revoke-on-stop? this)
                                     (seq (filter lease/leased? (vault/list-leases this))))]
           (log/infof "Revoking %d outstanding secret leases" (count outstanding))
@@ -61,7 +61,7 @@
               (catch Exception ex
                 (log/error ex "Failed to revoke lease" (:lease-id secret))))))
         (assoc this :lease-timer nil))
-      ; Already stopped.
+      ;; Already stopped.
       this))
 
 
@@ -95,7 +95,7 @@
                                  {"X-Vault-Wrap-TTL" ttl})
                       :form-params params
                       :content-type :json})]
-      ; Return auth info if available, or wrap info if not.
+      ;; Return auth info if available, or wrap info if not.
       (or (-> response :body :auth api-util/kebabify-keys)
           (-> response :body :wrap_info api-util/kebabify-keys)
           (throw (ex-info "No auth or wrap-info in response body"
@@ -191,9 +191,9 @@
                      {:form-params {:lease_id lease-id}
                       :content-type :json})
           info (api-util/clean-body response)]
-      ; If the lease looks renewable but the lease-duration is shorter than the
-      ; existing lease, we're up against the max-ttl and the lease should not
-      ; be considered renewable.
+      ;; If the lease looks renewable but the lease-duration is shorter than the
+      ;; existing lease, we're up against the max-ttl and the lease should not
+      ;; be considered renewable.
       (lease/update!
         leases
         (if (and (lease/renewable? info)

--- a/src/vault/client/mock.clj
+++ b/src/vault/client/mock.clj
@@ -110,7 +110,7 @@
 
   (renew-lease
     [_ _]
-    ; TODO: implement
+    ;; TODO: implement
     (throw (UnsupportedOperationException. "NYI")))
 
 

--- a/src/vault/env.clj
+++ b/src/vault/env.clj
@@ -8,7 +8,7 @@
     [clojure.string :as str]
     [clojure.tools.logging :as log]
     [envoy.core :refer [defenv]]
-    ; For extensions to vault.core/new-client multimethod.
+    ;; For extensions to vault.core/new-client multimethod.
     [vault.client.http]
     [vault.client.mock]
     [vault.core :as vault]
@@ -116,11 +116,11 @@
     (fn resolve-var
       [env' k]
       (if-let [v (get env' k)]
-        ; Does the env value start with the Vault prefix?
+        ;; Does the env value start with the Vault prefix?
         (if (str/starts-with? v vault-prefix)
           (assoc env' k (resolve-uri client v))
           env')
-        ; Value for k is not configured in env.
+        ;; Value for k is not configured in env.
         env'))
     env secrets))
 
@@ -132,8 +132,8 @@
    (load! nil env secrets))
   ([client env secrets]
    (if (seq secrets)
-     ; Some secrets, resolve paths.
+     ;; Some secrets, resolve paths.
      (let [client (or client (config-client env))]
        (resolve-secrets client env secrets))
-     ; No secrets, return env directly.
+     ;; No secrets, return env directly.
      env)))

--- a/src/vault/lease.clj
+++ b/src/vault/lease.clj
@@ -200,7 +200,7 @@
 
 (defn ^:no-doc maintain-leases!
   [client window]
-  (log/debug "Checking for renewable leases...")
+  (log/trace "Checking for renewable leases...")
   ;; Check auth token for renewal.
   (let [auth @(:auth client)]
     (when (and (:renewable auth)

--- a/src/vault/lease.clj
+++ b/src/vault/lease.clj
@@ -172,6 +172,7 @@
                   (:lease-id new-info))
         (watch-fn new-info)))))
 
+
 ;; ----- Lease operations that work on the client level -----------------------
 
 (defn ^:no-doc try-renew-lease!
@@ -200,7 +201,7 @@
 (defn ^:no-doc maintain-leases!
   [client window]
   (log/debug "Checking for renewable leases...")
-  ; Check auth token for renewal.
+  ;; Check auth token for renewal.
   (let [auth @(:auth client)]
     (when (and (:renewable auth)
                (expires-within? auth window))
@@ -209,14 +210,14 @@
         (vault/renew-token client)
         (catch Exception ex
           (log/error ex "Failed to renew client token!")))))
-  ; Renew leases that are within expiry window and are configured for renewal.
-  ; Rotate secrets that are about to expire and not renewable.
+  ;; Renew leases that are within expiry window and are configured for renewal.
+  ;; Rotate secrets that are about to expire and not renewable.
   (let [renewable (renewable-leases (:leases client) window)
         rotatable (rotatable-leases (:leases client) window)]
     (doseq [secret renewable]
       (try-renew-lease! client secret))
-    ; Rotate leases that are within expiry window and not renewable.
+    ;; Rotate leases that are within expiry window and not renewable.
     (doseq [secret rotatable]
       (try-rotate-secret! client secret)))
-  ; Drop any expired leases.
+  ;; Drop any expired leases.
   (sweep! (:leases client)))

--- a/src/vault/lease.clj
+++ b/src/vault/lease.clj
@@ -199,7 +199,7 @@
 
 (defn ^:no-doc maintain-leases!
   [client window]
-  (log/trace "Checking for renewable leases...")
+  (log/debug "Checking for renewable leases...")
   ; Check auth token for renewal.
   (let [auth @(:auth client)]
     (when (and (:renewable auth)

--- a/src/vault/timer.clj
+++ b/src/vault/timer.clj
@@ -23,7 +23,8 @@
             (catch Exception ex
               (log/error ex "Exception while running timer handler!")))
           (recur)))
-      (catch InterruptedException _
+      (catch Exception e
+        (log/debug "Exception" e)
         nil))))
 
 

--- a/src/vault/timer.clj
+++ b/src/vault/timer.clj
@@ -23,8 +23,7 @@
             (catch Exception ex
               (log/error ex "Exception while running timer handler!")))
           (recur)))
-      (catch Exception e
-        (log/debug "Exception" e)
+      (catch InterruptedException _
         nil))))
 
 

--- a/test/vault/client/http_test.clj
+++ b/test/vault/client/http_test.clj
@@ -24,7 +24,7 @@
     (is (thrown? IllegalArgumentException
           (vault-kvv1/read-secret client nil))
         "should throw an exception on non-string path")
-    (is (thrown? IllegalStateException
+    (is (thrown? RuntimeException
           (vault-kvv1/read-secret client "secret/foo/bar"))
         "should throw an exception on unauthenticated client")))
 
@@ -59,8 +59,7 @@
                  (str example-url "/v1/auth/kubernetes/login")
                  {:form-params {:jwt "fake-jwt-goes-here" :role "my-role"}
                   :content-type :json
-                  :accept :json
-                  :as :json}]]
+                  :accept :json}]]
                @api-requests))
         (is (= [[(str "Kubernetes auth role=my-role")
                  (:auth client)
@@ -116,8 +115,7 @@
                                 :iam_request_headers "{'foo':'bar'}"
                                 :role "my-role"}
                   :content-type :json
-                  :accept :json
-                  :as :json}]]
+                  :accept :json}]]
                @api-requests))
         (is (= [["AWS auth role=my-role"
                  (:auth client)

--- a/test/vault/secrets/kvv1_test.clj
+++ b/test/vault/secrets/kvv1_test.clj
@@ -1,6 +1,6 @@
 (ns vault.secrets.kvv1-test
   (:require
-    [clj-http.client]
+    [org.httpkit.client :as http]
     [clojure.test :refer [is testing deftest]]
     [vault.client.http :as http-client]
     [vault.client.mock-test :as mock-test]
@@ -26,7 +26,7 @@
     (vault/authenticate! client :token token-passed-in)
     (testing "List secrets has correct response and sends correct request"
       (with-redefs
-        [clj-http.client/request
+        [http/request
          (fn [req]
            (is (= :get (:method req)))
            (is (= (str vault-url "/v1/" path) (:url req)))
@@ -52,7 +52,7 @@
     (vault/authenticate! client :token token-passed-in)
     (testing "Read secrets sends correct request and responds correctly if secret is successfully located"
       (with-redefs
-        [clj-http.client/request
+        [http/request
          (fn [req]
            (is (= :get (:method req)))
            (is (= (str vault-url "/v1/" path-passed-in) (:url req)))
@@ -61,7 +61,7 @@
         (is (= {:foo "bar" :ttl "1h"} (vault-kvv1/read-secret client path-passed-in)))))
     (testing "Read secrets sends correct request and responds correctly if no secret is found"
       (with-redefs
-        [clj-http.client/request
+        [http/request
          (fn [req]
            (is (= (str vault-url "/v1/" path-passed-in2) (:url req)))
            (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
@@ -89,7 +89,7 @@
     (vault/authenticate! client :token token-passed-in)
     (testing "Write secrets sends correct request and returns true upon success"
       (with-redefs
-        [clj-http.client/request
+        [http/request
          (fn [req]
            (is (= :post (:method req)))
            (is (= (str vault-url "/v1/" path-passed-in) (:url req)))
@@ -100,7 +100,7 @@
         (is (true? (vault-kvv1/write-secret! client path-passed-in write-data)))))
     (testing "Write secrets sends correct request and returns false upon failure"
       (with-redefs
-        [clj-http.client/request
+        [http/request
          (fn [req]
            (is (= :post (:method req)))
            (is (= (str vault-url "/v1/" path-passed-in) (:url req)))
@@ -120,7 +120,7 @@
     (vault/authenticate! client :token "fake-token")
     (testing "Delete secret returns correctly upon success, and sends correct request"
       (with-redefs
-        [clj-http.client/request
+        [http/request
          (fn [req]
            (is (= :delete (:method req)))
            (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
@@ -129,7 +129,7 @@
         (is (true? (vault/delete-secret! client path-passed-in)))))
     (testing "Delete secret returns correctly upon failure, and sends correct request"
       (with-redefs
-        [clj-http.client/request
+        [http/request
          (fn [req]
            (is (= :delete (:method req)))
            (is (= token-passed-in (get (:headers req) "X-Vault-Token")))

--- a/test/vault/secrets/kvv1_test.clj
+++ b/test/vault/secrets/kvv1_test.clj
@@ -1,8 +1,8 @@
 (ns vault.secrets.kvv1-test
   (:require
-    [org.httpkit.client :as http]
-    [clojure.test :refer [is testing deftest]]
     [cheshire.core :as json]
+    [clojure.test :refer [is testing deftest]]
+    [org.httpkit.client :as http]
     [vault.client.http :as http-client]
     [vault.client.mock-test :as mock-test]
     [vault.core :as vault]

--- a/test/vault/secrets/kvv2_test.clj
+++ b/test/vault/secrets/kvv2_test.clj
@@ -1,13 +1,13 @@
 (ns vault.secrets.kvv2-test
   (:require
-    [org.httpkit.client :as http]
+    [cheshire.core :as json]
     [clojure.test :refer [testing deftest is]]
+    [org.httpkit.client :as http]
     [vault.client.api-util :as api-util]
     [vault.client.http :as http-client]
     [vault.client.mock-test :as mock-test]
     [vault.core :as vault]
-    [vault.secrets.kvv2 :as vault-kvv2]
-    [cheshire.core :as json])
+    [vault.secrets.kvv2 :as vault-kvv2])
   (:import
     (clojure.lang
       ExceptionInfo)))
@@ -84,10 +84,10 @@
 
 (deftest read-test
   (let [lookup-response-valid-path (json/generate-string {:data {:data     {:foo "bar"}
-                                                            :metadata {:created_time  "2018-03-22T02:24:06.945319214Z"
-                                                                       :deletion_time ""
-                                                                       :destroyed     false
-                                                                       :version       1}}})
+                                                                 :metadata {:created_time  "2018-03-22T02:24:06.945319214Z"
+                                                                            :deletion_time ""
+                                                                            :destroyed     false
+                                                                            :version       1}}})
         mount "mount"
         path-passed-in "path/passed/in"
         token-passed-in "fake-token"

--- a/test/vault/secrets/kvv2_test.clj
+++ b/test/vault/secrets/kvv2_test.clj
@@ -32,7 +32,7 @@
            (is (= (str vault-url "/v1/listmount/metadata/" path) (:url req)))
            (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
            (is (true? (-> req :query-params :list)))
-           {:body response})]
+           (atom {:body response}))]
         (is (= ["foo" "foo/"]
                (vault-kvv2/list-secrets client "listmount" path)))))))
 
@@ -57,7 +57,7 @@
            (is (= (str vault-url "/v1/" mount "/config") (:url req)))
            (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
            (is (= new-config-snake (:form-params req)))
-           {:status 204})]
+           (atom {:status 204}))]
         (is (true? (vault-kvv2/write-config! client mount new-config-kebab)))))))
 
 
@@ -65,6 +65,7 @@
   (let [config {:max-versions 5
                 :cas-required false
                 :delete-version-after "3h25m19s"}
+        body-str (json/generate-string {:data (api-util/snakeify-keys config)})
         mount "mount"
         token-passed-in "fake-token"
         vault-url "https://vault.example.amperity.com"
@@ -77,7 +78,7 @@
            (is (= :get (:method req)))
            (is (= (str vault-url "/v1/" mount "/config") (:url req)))
            (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
-           {:body {:data (api-util/snakeify-keys config)}})]
+           (atom {:body body-str}))]
         (is (= config (vault-kvv2/read-config client mount)))))))
 
 
@@ -158,13 +159,13 @@
            (is (= :post (:method req)))
            (if (= (str vault-url "/v1/" mount "/metadata/" path-passed-in) (:url req))
              (do (is (= {} (:form-params req)))
-                 {:errors []
-                  :status 200})
+                 (atom {:errors []
+                        :status 200}))
              (do (is (= (str vault-url "/v1/" mount "/data/" path-passed-in) (:url req)))
                  (is (= {:data write-data}
                         (:form-params req)))
-                 {:body create-success
-                  :status 200})))]
+                 (atom {:body create-success
+                        :status 200}))))]
         (is (= (:data create-success) (vault-kvv2/write-secret! client mount path-passed-in write-data)))))
     (testing "Write secrets sends correct request and returns false upon failure"
       (with-redefs
@@ -174,13 +175,13 @@
            (is (= :post (:method req)))
            (if (= (str vault-url "/v1/" mount "/metadata/other-path") (:url req))
              (do (is (= {} (:form-params req)))
-                 {:errors []
-                  :status 200})
+                 (atom {:errors []
+                        :status 200}))
              (do (is (= (str vault-url "/v1/" mount "/data/other-path") (:url req)))
                  (is (= {:data write-data}
                         (:form-params req)))
-                 {:errors []
-                  :status 500})))]
+                 (atom {:errors []
+                        :status 500}))))]
         (is (false? (vault-kvv2/write-secret! client mount "other-path" write-data)))))))
 
 
@@ -198,7 +199,7 @@
            (is (= :delete (:method req)))
            (is (= (str vault-url "/v1/" mount "/data/" path-passed-in) (:url req)))
            (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
-           {:status 204})]
+           (atom {:status 204}))]
         (is (true? (vault-kvv2/delete-secret! client mount path-passed-in))
             (is (true? (vault-kvv2/delete-secret! client mount path-passed-in []))))
         (testing "delete secrets send correct request and returns false upon failure when no versions passed in"
@@ -208,7 +209,7 @@
                (is (= :delete (:method req)))
                (is (= (str vault-url "/v1/" mount "/data/" path-passed-in) (:url req)))
                (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
-               {:status 404})]
+               (atom {:status 404}))]
             (is (false? (vault-kvv2/delete-secret! client mount path-passed-in)))))
         (testing "delete secrets send correct request and returns true upon success when multiple versions passed in"
           (with-redefs
@@ -218,7 +219,7 @@
                (is (= (str vault-url "/v1/" mount "/delete/" path-passed-in) (:url req)))
                (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
                (is (= {:versions [12 14 147]} (:form-params req)))
-               {:status 204})]
+               (atom {:status 204}))]
             (is (true? (vault-kvv2/delete-secret! client mount path-passed-in [12 14 147])))))
         (testing "delete secrets send correct request and returns false upon failure when multiple versions passed in"
           (with-redefs
@@ -228,40 +229,40 @@
                (is (= (str vault-url "/v1/" mount "/delete/" path-passed-in) (:url req)))
                (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
                (is (= {:versions [123]} (:form-params req)))
-               {:status 404})]
+               (atom {:status 404}))]
             (is (false? (vault-kvv2/delete-secret! client mount path-passed-in [123])))))))))
 
 
 (deftest read-metadata-test
-  (let [data {:data
-              {:created_time    "2018-03-22T02:24:06.945319214Z"
-               :current_version 3
-               :max_versions    0
-               :oldest_version  0
-               :updated_time    "2018-03-22T02:36:43.986212308Z"
-               :versions        {:1 {:created_time  "2018-03-22T02:24:06.945319214Z"
-                                     :deletion_time ""
-                                     :destroyed     false}
-                                 :2 {:created_time  "2018-03-22T02:36:33.954880664Z"
-                                     :deletion_time ""
-                                     :destroyed     false}
-                                 :3 {:created_time  "2018-03-22T02:36:43.986212308Z"
-                                     :deletion_time ""
-                                     :destroyed     false}}}}
-        kebab-metadata {:created-time    "2018-03-22T02:24:06.945319214Z"
-                        :current-version 3
-                        :max-versions    0
-                        :oldest-version  0
-                        :updated-time    "2018-03-22T02:36:43.986212308Z"
-                        :versions        {:1 {:created-time  "2018-03-22T02:24:06.945319214Z"
-                                              :deletion-time ""
-                                              :destroyed     false}
-                                          :2 {:created-time  "2018-03-22T02:36:33.954880664Z"
-                                              :deletion-time ""
-                                              :destroyed     false}
-                                          :3 {:created-time  "2018-03-22T02:36:43.986212308Z"
-                                              :deletion-time ""
-                                              :destroyed     false}}}
+  (let [data (json/generate-string {:data
+                                    {:created_time    "2018-03-22T02:24:06.945319214Z"
+                                     :current_version 3
+                                     :max_versions    0
+                                     :oldest_version  0
+                                     :updated_time    "2018-03-22T02:36:43.986212308Z"
+                                     :versions        {:1 {:created_time  "2018-03-22T02:24:06.945319214Z"
+                                                           :deletion_time ""
+                                                           :destroyed     false}
+                                                       :2 {:created_time  "2018-03-22T02:36:33.954880664Z"
+                                                           :deletion_time ""
+                                                           :destroyed     false}
+                                                       :3 {:created_time  "2018-03-22T02:36:43.986212308Z"
+                                                           :deletion_time ""
+                                                           :destroyed     false}}}})
+        kebab-metadata (json/generate-string {:created-time    "2018-03-22T02:24:06.945319214Z"
+                                              :current-version 3
+                                              :max-versions    0
+                                              :oldest-version  0
+                                              :updated-time    "2018-03-22T02:36:43.986212308Z"
+                                              :versions        {:1 {:created-time  "2018-03-22T02:24:06.945319214Z"
+                                                                    :deletion-time ""
+                                                                    :destroyed     false}
+                                                                :2 {:created-time  "2018-03-22T02:36:33.954880664Z"
+                                                                    :deletion-time ""
+                                                                    :destroyed     false}
+                                                                :3 {:created-time  "2018-03-22T02:36:43.986212308Z"
+                                                                    :deletion-time ""
+                                                                    :destroyed     false}}})
         mount "mount"
         path-passed-in "path/passed/in"
         token-passed-in "fake-token"
@@ -275,9 +276,9 @@
            (is (= :get (:method req)))
            (is (= (str vault-url "/v1/" mount "/metadata/" path-passed-in) (:url req)))
            (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
-           {:body   data
-            :status 200})]
-        (is (= kebab-metadata (vault-kvv2/read-metadata client mount path-passed-in)))))
+           (atom {:body   data
+                  :status 200}))]
+        (is (= kebab-metadata (json/generate-string (vault-kvv2/read-metadata client mount path-passed-in))))))
     (testing "Sends correct request and responds correctly when metadata not found"
       (with-redefs
         [http/request
@@ -309,7 +310,7 @@
            (is (= (str vault-url "/v1/" mount "/metadata/" path-passed-in) (:url req)))
            (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
            (is (= (api-util/snakeify-keys payload) (:form-params req)))
-           {:status 204})]
+           (atom {:status 204}))]
         (is (true? (vault-kvv2/write-metadata! client mount path-passed-in payload)))))
     (testing "Write metadata sends correct request and responds with false upon failure"
       (with-redefs
@@ -319,7 +320,7 @@
            (is (= (str vault-url "/v1/" mount "/metadata/" path-passed-in) (:url req)))
            (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
            (is (= (api-util/snakeify-keys payload) (:form-params req)))
-           {:status 500})]
+           (atom {:status 500}))]
         (is (false? (vault-kvv2/write-metadata! client mount path-passed-in payload)))))))
 
 
@@ -337,7 +338,7 @@
            (is (= :delete (:method req)))
            (is (= (str vault-url "/v1/" mount "/metadata/" path-passed-in) (:url req)))
            (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
-           {:status 204})]
+           (atom {:status 204}))]
         (is (true? (vault-kvv2/delete-metadata! client mount path-passed-in)))))
     (testing "Sends correct request and responds correctly upon failure"
       (with-redefs
@@ -346,7 +347,7 @@
            (is (= :delete (:method req)))
            (is (= (str vault-url "/v1/" mount "/metadata/" path-passed-in) (:url req)))
            (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
-           {:status 500})]
+           (atom {:status 500}))]
         (is (false? (vault-kvv2/delete-metadata! client mount path-passed-in)))))))
 
 
@@ -367,7 +368,7 @@
            (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
            (is (= {:versions versions}
                   (:form-params req)))
-           {:status 204})]
+           (atom {:status 204}))]
         (is (true? (vault-kvv2/destroy-secret! client mount path-passed-in versions)))))
     (testing "Destroy secrets sends correct request and returns false upon failure"
       (with-redefs
@@ -378,7 +379,7 @@
            (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
            (is (= {:versions [1]}
                   (:form-params req)))
-           {:status 500})]
+           (atom {:status 500}))]
         (is (false? (vault-kvv2/destroy-secret! client mount path-passed-in [1])))))))
 
 
@@ -399,7 +400,7 @@
            (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
            (is (= {:versions versions}
                   (:form-params req)))
-           {:status 204})]
+           (atom {:status 204}))]
         (is (true? (vault-kvv2/undelete-secret! client mount path-passed-in versions)))))
     (testing "Undelete secrets sends correct request and returns false upon failure"
       (with-redefs
@@ -410,7 +411,7 @@
            (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
            (is (= {:versions [1]}
                   (:form-params req)))
-           {:status 500})]
+           (atom {:status 500}))]
         (is (false? (vault-kvv2/undelete-secret! client mount path-passed-in [1])))))))
 
 

--- a/test/vault/secrets/kvv2_test.clj
+++ b/test/vault/secrets/kvv2_test.clj
@@ -1,6 +1,6 @@
 (ns vault.secrets.kvv2-test
   (:require
-    [clj-http.client]
+    [org.httpkit.client :as http]
     [clojure.test :refer [testing deftest is]]
     [vault.client.api-util :as api-util]
     [vault.client.http :as http-client]
@@ -25,7 +25,7 @@
     (vault/authenticate! client :token token-passed-in)
     (testing "List secrets has correct response and sends correct request"
       (with-redefs
-        [clj-http.client/request
+        [http/request
          (fn [req]
            (is (= :get (:method req)))
            (is (= (str vault-url "/v1/listmount/metadata/" path) (:url req)))
@@ -50,7 +50,7 @@
     (vault/authenticate! client :token token-passed-in)
     (testing "Write config sends correct request and returns true on valid call"
       (with-redefs
-        [clj-http.client/request
+        [http/request
          (fn [req]
            (is (= :post (:method req)))
            (is (= (str vault-url "/v1/" mount "/config") (:url req)))
@@ -71,7 +71,7 @@
     (vault/authenticate! client :token token-passed-in)
     (testing "Read config sends correct request and returns the config with valid call"
       (with-redefs
-        [clj-http.client/request
+        [http/request
          (fn [req]
            (is (= :get (:method req)))
            (is (= (str vault-url "/v1/" mount "/config") (:url req)))
@@ -94,7 +94,7 @@
     (vault/authenticate! client :token token-passed-in)
     (testing "Read secrets sends correct request and responds correctly if secret is successfully located"
       (with-redefs
-        [clj-http.client/request
+        [http/request
          (fn [req]
            (is (= :get (:method req)))
            (is (= (str vault-url "/v1/" mount "/data/" path-passed-in) (:url req)))
@@ -103,7 +103,7 @@
         (is (= {:foo "bar"} (vault-kvv2/read-secret client mount path-passed-in)))))
     (testing "Read secrets sends correct request and responds correctly if secret with version is successfully located"
       (with-redefs
-        [clj-http.client/request
+        [http/request
          (fn [req]
            (is (= :get (:method req)))
            (is (= (str vault-url "/v1/" mount "/data/" path-passed-in) (:url req)))
@@ -113,7 +113,7 @@
         (is (= {:foo "bar"} (vault-kvv2/read-secret client mount path-passed-in {:version 3 :force-read true})))))
     (testing "Read secrets sends correct request and responds correctly if no secret is found"
       (with-redefs
-        [clj-http.client/request
+        [http/request
          (fn [req]
            (is (= :get (:method req)))
            (is (= (str vault-url "/v1/" mount "/data/different/path") (:url req)))
@@ -151,7 +151,7 @@
     (vault/authenticate! client :token token-passed-in)
     (testing "Write secrets sends correct request and returns true upon success"
       (with-redefs
-        [clj-http.client/request
+        [http/request
          (fn [req]
            (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
            (is (= :post (:method req)))
@@ -167,7 +167,7 @@
         (is (= (:data create-success) (vault-kvv2/write-secret! client mount path-passed-in write-data)))))
     (testing "Write secrets sends correct request and returns false upon failure"
       (with-redefs
-        [clj-http.client/request
+        [http/request
          (fn [req]
            (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
            (is (= :post (:method req)))
@@ -192,7 +192,7 @@
     (vault/authenticate! client :token token-passed-in)
     (testing "delete secrets send correct request and returns true upon success when no versions passed in"
       (with-redefs
-        [clj-http.client/request
+        [http/request
          (fn [req]
            (is (= :delete (:method req)))
            (is (= (str vault-url "/v1/" mount "/data/" path-passed-in) (:url req)))
@@ -202,7 +202,7 @@
             (is (true? (vault-kvv2/delete-secret! client mount path-passed-in []))))
         (testing "delete secrets send correct request and returns false upon failure when no versions passed in"
           (with-redefs
-            [clj-http.client/request
+            [http/request
              (fn [req]
                (is (= :delete (:method req)))
                (is (= (str vault-url "/v1/" mount "/data/" path-passed-in) (:url req)))
@@ -211,7 +211,7 @@
             (is (false? (vault-kvv2/delete-secret! client mount path-passed-in)))))
         (testing "delete secrets send correct request and returns true upon success when multiple versions passed in"
           (with-redefs
-            [clj-http.client/request
+            [http/request
              (fn [req]
                (is (= :post (:method req)))
                (is (= (str vault-url "/v1/" mount "/delete/" path-passed-in) (:url req)))
@@ -221,7 +221,7 @@
             (is (true? (vault-kvv2/delete-secret! client mount path-passed-in [12 14 147])))))
         (testing "delete secrets send correct request and returns false upon failure when multiple versions passed in"
           (with-redefs
-            [clj-http.client/request
+            [http/request
              (fn [req]
                (is (= :post (:method req)))
                (is (= (str vault-url "/v1/" mount "/delete/" path-passed-in) (:url req)))
@@ -269,7 +269,7 @@
     (vault/authenticate! client :token token-passed-in)
     (testing "Sends correct request and responds correctly upon success"
       (with-redefs
-        [clj-http.client/request
+        [http/request
          (fn [req]
            (is (= :get (:method req)))
            (is (= (str vault-url "/v1/" mount "/metadata/" path-passed-in) (:url req)))
@@ -279,7 +279,7 @@
         (is (= kebab-metadata (vault-kvv2/read-metadata client mount path-passed-in)))))
     (testing "Sends correct request and responds correctly when metadata not found"
       (with-redefs
-        [clj-http.client/request
+        [http/request
          (fn [req]
            (is (= :get (:method req)))
            (is (= (str vault-url "/v1/" mount "/metadata/" path-passed-in) (:url req)))
@@ -302,7 +302,7 @@
     (vault/authenticate! client :token token-passed-in)
     (testing "Write metadata sends correct request and responds with true upon success"
       (with-redefs
-        [clj-http.client/request
+        [http/request
          (fn [req]
            (is (= :post (:method req)))
            (is (= (str vault-url "/v1/" mount "/metadata/" path-passed-in) (:url req)))
@@ -312,7 +312,7 @@
         (is (true? (vault-kvv2/write-metadata! client mount path-passed-in payload)))))
     (testing "Write metadata sends correct request and responds with false upon failure"
       (with-redefs
-        [clj-http.client/request
+        [http/request
          (fn [req]
            (is (= :post (:method req)))
            (is (= (str vault-url "/v1/" mount "/metadata/" path-passed-in) (:url req)))
@@ -331,7 +331,7 @@
     (vault/authenticate! client :token token-passed-in)
     (testing "Sends correct request and responds correctly upon success"
       (with-redefs
-        [clj-http.client/request
+        [http/request
          (fn [req]
            (is (= :delete (:method req)))
            (is (= (str vault-url "/v1/" mount "/metadata/" path-passed-in) (:url req)))
@@ -340,7 +340,7 @@
         (is (true? (vault-kvv2/delete-metadata! client mount path-passed-in)))))
     (testing "Sends correct request and responds correctly upon failure"
       (with-redefs
-        [clj-http.client/request
+        [http/request
          (fn [req]
            (is (= :delete (:method req)))
            (is (= (str vault-url "/v1/" mount "/metadata/" path-passed-in) (:url req)))
@@ -359,7 +359,7 @@
     (vault/authenticate! client :token token-passed-in)
     (testing "Destroy secrets sends correct request and returns true upon success"
       (with-redefs
-        [clj-http.client/request
+        [http/request
          (fn [req]
            (is (= :post (:method req)))
            (is (= (str vault-url "/v1/" mount "/destroy/" path-passed-in) (:url req)))
@@ -370,7 +370,7 @@
         (is (true? (vault-kvv2/destroy-secret! client mount path-passed-in versions)))))
     (testing "Destroy secrets sends correct request and returns false upon failure"
       (with-redefs
-        [clj-http.client/request
+        [http/request
          (fn [req]
            (is (= :post (:method req)))
            (is (= (str vault-url "/v1/" mount "/destroy/" path-passed-in) (:url req)))
@@ -391,7 +391,7 @@
     (vault/authenticate! client :token token-passed-in)
     (testing "Undelete secrets sends correct request and returns true upon success"
       (with-redefs
-        [clj-http.client/request
+        [http/request
          (fn [req]
            (is (= :post (:method req)))
            (is (= (str vault-url "/v1/" mount "/undelete/" path-passed-in) (:url req)))
@@ -402,7 +402,7 @@
         (is (true? (vault-kvv2/undelete-secret! client mount path-passed-in versions)))))
     (testing "Undelete secrets sends correct request and returns false upon failure"
       (with-redefs
-        [clj-http.client/request
+        [http/request
          (fn [req]
            (is (= :post (:method req)))
            (is (= (str vault-url "/v1/" mount "/undelete/" path-passed-in) (:url req)))


### PR DESCRIPTION
This is a rough PR - mainly to visualize the amount of changes. 

* I migrated from clj-http to httpkit (API is mostly compatible) - minimal changes
* Added deps.edn for easier consumption of library via git url or local url
* Added bb.edn with sample script to test secret extraction from vault
* Changed clean-body function to make it work with vault 1.7.x API
* Replaced commons hex with clojure equivalent

Fixes #53 

Ideas for improvement:
* Add integration tests using https://www.testcontainers.org/  - start vault in a container and run API tests against it