### PR TITLE
Fix 1.0.4

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject amperity/vault-clj "1.0.4"
+(defproject amperity/vault-clj "1.0.5-SNAPSHOT"
   :description "Clojure client for the Vault secret management system."
   :url "https://github.com/amperity/vault-clj"
   :license {:name "Apache License"

--- a/src/vault/authenticate.clj
+++ b/src/vault/authenticate.clj
@@ -11,7 +11,7 @@
   "Validate the response from a vault auth call, update auth-ref with additional
   tracking state like lease metadata."
   [claim auth-ref response]
-  (let [auth-info (lease/auth-lease (:auth (api-util/clean-body response)))]
+  (let [auth-info (lease/auth-lease (:auth (:body response)))]
     (when-not (:client-token auth-info)
       (throw (ex-info (str "No client token returned from non-error API response: "
                            (:status response) " " (:reason-phrase response))

--- a/src/vault/client/api_util.clj
+++ b/src/vault/client/api_util.clj
@@ -76,12 +76,13 @@
   dropping extraneous information. Note that this changes the `:data` in the
   response to the original result to preserve accuracy."
   [body]
-  (let [parsed (json/parse-string body true)]
-    (-> parsed
-        (dissoc :data)
-        (kebabify-keys)
-        (assoc :data (:data parsed))
-        (->> (into {} (filter (comp some? val)))))))
+  (when body
+    (let [parsed (json/parse-string body true)]
+      (-> parsed
+          (dissoc :data)
+          (kebabify-keys)
+          (assoc :data (:data parsed))
+          (->> (into {} (filter (comp some? val))))))))
 
 
 (defn ^:no-doc api-error

--- a/src/vault/client/api_util.clj
+++ b/src/vault/client/api_util.clj
@@ -107,6 +107,20 @@
       ex)))
 
 
+(defn- handle-response-errors
+  "Throws exceptions from http-kit response mimicing clj-http."
+  [response]
+  (cond
+    (:error response)
+    (throw (ex-info "Error in api response" response (:error response)))
+
+    (<= 400 (:status response))
+    (throw (ex-info (str "status: " (:status response)) response))
+
+    :else
+    response))
+
+
 (defn ^:no-doc do-api-request
   "Performs a request against the API, following redirects at most twice. The
   `request-url` should be the full API endpoint."
@@ -125,6 +139,7 @@
                    (assoc :method method :url request-url)
                    (http/request)
                    (deref)
+                   (handle-response-errors)
                    (update :body clean-body))
                  (catch Exception ex
                    (log/debug "Exception " ex)

--- a/src/vault/client/api_util.clj
+++ b/src/vault/client/api_util.clj
@@ -106,7 +106,7 @@
         status (:status data)]
     (if (or error (and status (<= 400 status)))
       (let [errors (if error (ex-message error) (body-errors data))]
-        (ex-info (str "Vault API errors: " errors)
+        (ex-info (str "Vault API server errors: " errors)
                  {:type ::api-error
                   :status status
                   :errors errors}

--- a/src/vault/client/api_util.clj
+++ b/src/vault/client/api_util.clj
@@ -71,15 +71,17 @@
     (encode-hex-string (.digest hasher))))
 
 
-(defn ^:no-doc clean-body
+(defn- ^:no-doc clean-body
   "Cleans up a response from the Vault API by rewriting some keywords and
   dropping extraneous information. Note that this changes the `:data` in the
   response to the original result to preserve accuracy."
-  [response]
-  (->
-    (:body response)
-    (json/parse-string true)
-    (kebabify-keys)))
+  [body]
+  (let [parsed (json/parse-string body true)]
+    (-> parsed
+        (dissoc :data)
+        (kebabify-keys)
+        (assoc :data (:data parsed))
+        (->> (into {} (filter (comp some? val)))))))
 
 
 (defn ^:no-doc api-error
@@ -113,8 +115,16 @@
       (throw (ex-info (str "Aborting Vault API request after " redirects " redirects")
                       {:method method, :url request-url})))
     (let [resp (try
-                 (let [response (http/request (assoc req :method method :url request-url))]
-                   @response)
+                 (->
+                   req
+                   (cond->
+                     (and (= :json (:content-type req))
+                          (:body req))
+                     (update :body json/generate-string))
+                   (assoc :method method :url request-url)
+                   (http/request)
+                   (deref)
+                   (update :body clean-body))
                  (catch Exception ex
                    (log/debug "Exception " ex)
                    (throw (api-error ex))))]

--- a/src/vault/lease.clj
+++ b/src/vault/lease.clj
@@ -192,7 +192,7 @@
   (try
     (log/info "Rotating secret lease" (:lease-id secret))
     (let [response (api-util/api-request client :get (:path secret) {})
-          info (assoc (api-util/clean-body response) :path (:path secret))]
+          info (assoc (:body response) :path (:path secret))]
       (update! (:leases client) info))
     (catch Exception ex
       (log/error ex "Failed to rotate secret" (:lease-id secret)))))

--- a/src/vault/secrets/kvv2.clj
+++ b/src/vault/secrets/kvv2.clj
@@ -89,7 +89,9 @@
 
 
 (defn write-secret!
-  "Writes secret data to a path. Returns a boolean indicating whether the write was successful.
+  "Writes secret data to a path.
+
+  Returns a boolean indicating whether the write was successful or throws an exception if an error occured.
 
   Params:
   - `client`: `vault.client`, A client that handles vault auth, leases, and basic CRUD ops
@@ -105,7 +107,8 @@
 
 (defn write-config!
   "Configures backend level settings that are applied to every key in the key-value store for a given secret engine.
-   Returns a boolean indicating whether the write was successful.
+
+  Returns a boolean indicating whether the write was successful or throws an exception if an error occured.
 
   Params:
   - `client`: `vault.client`, A client that handles vault auth, leases, and basic CRUD ops
@@ -138,7 +141,8 @@
 
 (defn destroy-secret!
   "Permanently removes the specified version data for the provided key and version numbers from the key-value store.
-  Returns a boolean indicating whether the destroy was successful.
+
+  Returns a boolean indicating whether the destroy was successful or throws and exception if an error occured.
 
   Params:
   - `client`: `vault.client`, A client that handles vault auth, leases, and basic CRUD ops

--- a/test/vault/client/mock_test.clj
+++ b/test/vault/client/mock_test.clj
@@ -2,6 +2,7 @@
   (:require
     [clojure.string :as str]
     [clojure.test :refer [deftest testing is]]
+    [vault.client.mock]
     [vault.core :as vault])
   (:import
     (clojure.lang

--- a/test/vault/secrets/kvv1_test.clj
+++ b/test/vault/secrets/kvv1_test.clj
@@ -19,11 +19,12 @@
         token-passed-in "fake-token"
         vault-url "https://vault.example.amperity.com"
         client (http-client/http-client vault-url)
-        response {:auth nil
-                  :data {:keys ["foo" "foo/"]}
-                  :lease_duration 2764800
-                  :lease-id ""
-                  :renewable false}]
+        response (json/generate-string
+                   {:auth nil
+                    :data {:keys ["foo" "foo/"]}
+                    :lease-duration 2764800
+                    :lease-id ""
+                    :renewable false})]
     (vault/authenticate! client :token token-passed-in)
     (testing "List secrets has correct response and sends correct request"
       (with-redefs
@@ -95,7 +96,7 @@
            (is (= :post (:method req)))
            (is (= (str vault-url "/v1/" path-passed-in) (:url req)))
            (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
-           (is (= write-data (:form-params req)))
+           (is (= (json/generate-string write-data) (:body req)))
            (atom {:body create-success
                   :status 204}))]
         (is (true? (vault-kvv1/write-secret! client path-passed-in write-data)))))
@@ -106,8 +107,7 @@
            (is (= :post (:method req)))
            (is (= (str vault-url "/v1/" path-passed-in) (:url req)))
            (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
-           (is (= write-data
-                  (:form-params req)))
+           (is (= (json/generate-string write-data) (:body req)))
            (atom {:errors []
                   :status 400}))]
         (is (false? (vault-kvv1/write-secret! client path-passed-in write-data)))))))

--- a/test/vault/secrets/kvv1_test.clj
+++ b/test/vault/secrets/kvv1_test.clj
@@ -67,14 +67,11 @@
          (fn [req]
            (is (= (str vault-url "/v1/" path-passed-in2) (:url req)))
            (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
-           (throw (ex-info "not found" {:error [] :status 404})))]
-        (try
-          (vault-kvv1/read-secret client path-passed-in2)
-          (catch ExceptionInfo e
-            (is (= {:errors nil
-                    :status 404
-                    :type   :vault.client.api-util/api-error}
-                   (ex-data e)))))))))
+           (atom {:status 404}))]
+        (is (thrown-with-msg?
+              ExceptionInfo
+              #"Vault API server error"
+              (vault-kvv1/read-secret client path-passed-in2)))))))
 
 
 (deftest write-secret-test
@@ -100,7 +97,7 @@
            (atom {:body create-success
                   :status 204}))]
         (is (true? (vault-kvv1/write-secret! client path-passed-in write-data)))))
-    (testing "Write secrets sends correct request and returns false upon failure"
+    (testing "Write secrets sends correct request and throws an exception upon failure"
       (with-redefs
         [http/request
          (fn [req]
@@ -108,9 +105,11 @@
            (is (= (str vault-url "/v1/" path-passed-in) (:url req)))
            (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
            (is (= (json/generate-string write-data) (:body req)))
-           (atom {:errors []
-                  :status 400}))]
-        (is (false? (vault-kvv1/write-secret! client path-passed-in write-data)))))))
+           (atom {:status 400}))]
+        (is (thrown-with-msg?
+              ExceptionInfo
+              #"Vault API server error"
+              (vault-kvv1/write-secret! client path-passed-in write-data)))))))
 
 
 (deftest delete-secret-test
@@ -136,7 +135,10 @@
            (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
            (is (= (str vault-url "/v1/" path-passed-in) (:url req)))
            (atom {:status 404}))]
-        (is (false? (vault/delete-secret! client path-passed-in)))))))
+        (is (thrown-with-msg?
+              ExceptionInfo
+              #"Vault API server error"
+              (vault/delete-secret! client path-passed-in)))))))
 
 
 ;; -------- Mock Client -------------------------------------------------------

--- a/test/vault/secrets/kvv2_test.clj
+++ b/test/vault/secrets/kvv2_test.clj
@@ -18,11 +18,12 @@
         token-passed-in "fake-token"
         vault-url "https://vault.example.amperity.com"
         client (http-client/http-client vault-url)
-        response {:auth nil
-                  :data {:keys ["foo" "foo/"]}
-                  :lease_duration 2764800
-                  :lease_id ""
-                  :renewable false}]
+        response (json/generate-string
+                   {:auth nil
+                    :data {:keys ["foo" "foo/"]}
+                    :lease_duration 2764800
+                    :lease_id ""
+                    :renewable false})]
     (vault/authenticate! client :token token-passed-in)
     (testing "List secrets has correct response and sends correct request"
       (with-redefs
@@ -56,7 +57,7 @@
            (is (= :post (:method req)))
            (is (= (str vault-url "/v1/" mount "/config") (:url req)))
            (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
-           (is (= new-config-snake (:form-params req)))
+           (is (= (json/generate-string new-config-snake) (:body req)))
            (atom {:status 204}))]
         (is (true? (vault-kvv2/write-config! client mount new-config-kebab)))))))
 
@@ -158,13 +159,13 @@
            (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
            (is (= :post (:method req)))
            (if (= (str vault-url "/v1/" mount "/metadata/" path-passed-in) (:url req))
-             (do (is (= {} (:form-params req)))
+             (do (is (= (json/generate-string {}) (:body req)))
                  (atom {:errors []
                         :status 200}))
              (do (is (= (str vault-url "/v1/" mount "/data/" path-passed-in) (:url req)))
-                 (is (= {:data write-data}
-                        (:form-params req)))
-                 (atom {:body create-success
+                 (is (= (json/generate-string {:data write-data})
+                        (:body req)))
+                 (atom {:body (json/generate-string create-success)
                         :status 200}))))]
         (is (= (:data create-success) (vault-kvv2/write-secret! client mount path-passed-in write-data)))))
     (testing "Write secrets sends correct request and returns false upon failure"
@@ -174,12 +175,12 @@
            (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
            (is (= :post (:method req)))
            (if (= (str vault-url "/v1/" mount "/metadata/other-path") (:url req))
-             (do (is (= {} (:form-params req)))
+             (do (is (= (json/generate-string {}) (:body req)))
                  (atom {:errors []
                         :status 200}))
              (do (is (= (str vault-url "/v1/" mount "/data/other-path") (:url req)))
-                 (is (= {:data write-data}
-                        (:form-params req)))
+                 (is (= (json/generate-string {:data write-data})
+                        (:body req)))
                  (atom {:errors []
                         :status 500}))))]
         (is (false? (vault-kvv2/write-secret! client mount "other-path" write-data)))))))
@@ -218,7 +219,7 @@
                (is (= :post (:method req)))
                (is (= (str vault-url "/v1/" mount "/delete/" path-passed-in) (:url req)))
                (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
-               (is (= {:versions [12 14 147]} (:form-params req)))
+               (is (= (json/generate-string {:versions [12 14 147]}) (:body req)))
                (atom {:status 204}))]
             (is (true? (vault-kvv2/delete-secret! client mount path-passed-in [12 14 147])))))
         (testing "delete secrets send correct request and returns false upon failure when multiple versions passed in"
@@ -228,7 +229,7 @@
                (is (= :post (:method req)))
                (is (= (str vault-url "/v1/" mount "/delete/" path-passed-in) (:url req)))
                (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
-               (is (= {:versions [123]} (:form-params req)))
+               (is (= (json/generate-string {:versions [123]}) (:body req)))
                (atom {:status 404}))]
             (is (false? (vault-kvv2/delete-secret! client mount path-passed-in [123])))))))))
 
@@ -249,20 +250,20 @@
                                                        :3 {:created_time  "2018-03-22T02:36:43.986212308Z"
                                                            :deletion_time ""
                                                            :destroyed     false}}}})
-        kebab-metadata (json/generate-string {:created-time    "2018-03-22T02:24:06.945319214Z"
-                                              :current-version 3
-                                              :max-versions    0
-                                              :oldest-version  0
-                                              :updated-time    "2018-03-22T02:36:43.986212308Z"
-                                              :versions        {:1 {:created-time  "2018-03-22T02:24:06.945319214Z"
-                                                                    :deletion-time ""
-                                                                    :destroyed     false}
-                                                                :2 {:created-time  "2018-03-22T02:36:33.954880664Z"
-                                                                    :deletion-time ""
-                                                                    :destroyed     false}
-                                                                :3 {:created-time  "2018-03-22T02:36:43.986212308Z"
-                                                                    :deletion-time ""
-                                                                    :destroyed     false}}})
+        kebab-metadata {:created-time    "2018-03-22T02:24:06.945319214Z"
+                        :current-version 3
+                        :max-versions    0
+                        :oldest-version  0
+                        :updated-time    "2018-03-22T02:36:43.986212308Z"
+                        :versions        {:1 {:created-time  "2018-03-22T02:24:06.945319214Z"
+                                              :deletion-time ""
+                                              :destroyed     false}
+                                          :2 {:created-time  "2018-03-22T02:36:33.954880664Z"
+                                              :deletion-time ""
+                                              :destroyed     false}
+                                          :3 {:created-time  "2018-03-22T02:36:43.986212308Z"
+                                              :deletion-time ""
+                                              :destroyed     false}}}
         mount "mount"
         path-passed-in "path/passed/in"
         token-passed-in "fake-token"
@@ -278,7 +279,7 @@
            (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
            (atom {:body   data
                   :status 200}))]
-        (is (= kebab-metadata (json/generate-string (vault-kvv2/read-metadata client mount path-passed-in))))))
+        (is (= kebab-metadata (vault-kvv2/read-metadata client mount path-passed-in)))))
     (testing "Sends correct request and responds correctly when metadata not found"
       (with-redefs
         [http/request
@@ -309,7 +310,7 @@
            (is (= :post (:method req)))
            (is (= (str vault-url "/v1/" mount "/metadata/" path-passed-in) (:url req)))
            (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
-           (is (= (api-util/snakeify-keys payload) (:form-params req)))
+           (is (= (json/generate-string (api-util/snakeify-keys payload)) (:body req)))
            (atom {:status 204}))]
         (is (true? (vault-kvv2/write-metadata! client mount path-passed-in payload)))))
     (testing "Write metadata sends correct request and responds with false upon failure"
@@ -319,7 +320,7 @@
            (is (= :post (:method req)))
            (is (= (str vault-url "/v1/" mount "/metadata/" path-passed-in) (:url req)))
            (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
-           (is (= (api-util/snakeify-keys payload) (:form-params req)))
+           (is (= (json/generate-string (api-util/snakeify-keys payload)) (:body req)))
            (atom {:status 500}))]
         (is (false? (vault-kvv2/write-metadata! client mount path-passed-in payload)))))))
 
@@ -366,8 +367,8 @@
            (is (= :post (:method req)))
            (is (= (str vault-url "/v1/" mount "/destroy/" path-passed-in) (:url req)))
            (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
-           (is (= {:versions versions}
-                  (:form-params req)))
+           (is (= (json/generate-string {:versions versions})
+                  (:body req)))
            (atom {:status 204}))]
         (is (true? (vault-kvv2/destroy-secret! client mount path-passed-in versions)))))
     (testing "Destroy secrets sends correct request and returns false upon failure"
@@ -377,8 +378,8 @@
            (is (= :post (:method req)))
            (is (= (str vault-url "/v1/" mount "/destroy/" path-passed-in) (:url req)))
            (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
-           (is (= {:versions [1]}
-                  (:form-params req)))
+           (is (= (json/generate-string {:versions [1]})
+                  (:body req)))
            (atom {:status 500}))]
         (is (false? (vault-kvv2/destroy-secret! client mount path-passed-in [1])))))))
 
@@ -398,8 +399,8 @@
            (is (= :post (:method req)))
            (is (= (str vault-url "/v1/" mount "/undelete/" path-passed-in) (:url req)))
            (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
-           (is (= {:versions versions}
-                  (:form-params req)))
+           (is (= (json/generate-string {:versions versions})
+                  (:body req)))
            (atom {:status 204}))]
         (is (true? (vault-kvv2/undelete-secret! client mount path-passed-in versions)))))
     (testing "Undelete secrets sends correct request and returns false upon failure"
@@ -409,8 +410,8 @@
            (is (= :post (:method req)))
            (is (= (str vault-url "/v1/" mount "/undelete/" path-passed-in) (:url req)))
            (is (= token-passed-in (get (:headers req) "X-Vault-Token")))
-           (is (= {:versions [1]}
-                  (:form-params req)))
+           (is (= (json/generate-string {:versions [1]})
+                  (:body req)))
            (atom {:status 500}))]
         (is (false? (vault-kvv2/undelete-secret! client mount path-passed-in [1])))))))
 


### PR DESCRIPTION
Relates to #54 changes that broke secrets kv1 and kv2.

This primarily restores the expected/correct json parsing/handling making requests to vault.

- Use api-utils/clean-body by default, internal to the do-api-request
- Serialize json body for json post, put, patch requests by default

In retrospect, I am not sure what this means

> Changed clean-body function to make it work with vault 1.7.x API

And have basically reverted behavior except for json parsing.