### PR TITLE
Update dependencies to latest versions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,12 +8,12 @@
   :pedantic? :abort
 
   :plugins
-  [[lein-cloverage "1.2.1"]]
+  [[lein-cloverage "1.2.2"]]
 
   :dependencies
-  [[org.clojure/clojure "1.10.1"]
-   [org.clojure/tools.logging "1.1.0"]
-   [amperity/envoy "0.3.3"]
+  [[org.clojure/clojure "1.10.3"]
+   [org.clojure/tools.logging "1.2.3"]
+   [amperity/envoy "1.0.0"]
    [cheshire "5.10.1"]
    [http-kit "2.5.3"]
    [com.stuartsierra/component "1.0.0"]]
@@ -26,10 +26,10 @@
   {:dev
    {:dependencies
     [[org.clojure/tools.trace "0.7.11"]
-     [ch.qos.logback/logback-classic "1.2.5"]]
+     [ch.qos.logback/logback-classic "1.2.10"]]
     :jvm-opts ["-Dclojure.main.report=stderr"]}
 
    :repl
    {:source-paths ["dev"]
-    :dependencies [[org.clojure/tools.namespace "1.1.0"]]
+    :dependencies [[org.clojure/tools.namespace "1.2.0"]]
     :jvm-opts ["-Dvault.log.appender=repl"]}})


### PR DESCRIPTION
lein-cloverage 1.2.1 -> 1.2.2
clojure 1.10.1 -> 1.10.3
org.clojure/tools.logging 1.1.0 -> 1.2.3
amperity/envoy 0.3.3 -> 1.0.0
ch.qos.logback/logback-classic 1.2.5 -> 1.2.10
org.clojure/tools.namespace 1.1.0 -> 1.2.0