### PR TITLE
Add create-orphan-token! method

### DIFF
--- a/src/vault/client/mock.clj
+++ b/src/vault/client/mock.clj
@@ -101,6 +101,11 @@
            :metadata       nil}))))
 
 
+  (create-orphan-token!
+    [this opts]
+    (.create-token! this (assoc opts :no-parent true)))
+
+
   vault/LeaseManager
 
   (list-leases

--- a/src/vault/core.clj
+++ b/src/vault/core.clj
@@ -64,6 +64,12 @@
     - `:wrap-ttl` Returns a wrapped response with a wrap-token valid for the
       given number of seconds.")
 
+  (create-orphan-token!
+    [client opts]
+    "Creates a new token. Just like `create-token!`, but uses the
+    `/auth/token/create-orphan` endpoint, so `:no-parent` is always implicitly
+    true.")
+
   (lookup-token
     [client]
     [client token]


### PR DESCRIPTION
Add support for the `/auth/token/create-orphan` endpoint, so that we can securely give services permissions to create orphan tokens without `sudo` on the main `/auth/token/create` endpoint.