### PR TITLE
Add Userpass auth method

### DIFF
--- a/dev/vault/repl.clj
+++ b/dev/vault/repl.clj
@@ -7,6 +7,7 @@
     [clojure.tools.namespace.repl :refer [refresh]]
     [vault.auth :as auth]
     [vault.auth.token :as auth.token]
+    [vault.auth.userpass :as auth.userpass]
     [vault.client :as vault]
     [vault.client.flow :as f]
     [vault.client.http :as http]

--- a/src/vault/auth/token.clj
+++ b/src/vault/auth/token.clj
@@ -128,13 +128,6 @@
 
 ;; ## HTTP Client
 
-(defn- kebabify-body-auth
-  "Look up a map in the provided body under the `\"auth\"` key and kebabify
-  it."
-  [body]
-  (u/kebabify-keys (get body "auth")))
-
-
 (extend-type HTTPClient
 
   API
@@ -145,7 +138,7 @@
       client :post "auth/token/create"
       {:content-type :json
        :body (u/snakify-keys params)
-       :handle-response kebabify-body-auth}))
+       :handle-response u/kebabify-body-auth}))
 
 
   (create-orphan-token!
@@ -154,7 +147,7 @@
       client :post "auth/token/create-orphan"
       {:content-type :json
        :body (u/snakify-keys params)
-       :handle-response kebabify-body-auth}))
+       :handle-response u/kebabify-body-auth}))
 
 
   (create-role-token!
@@ -163,7 +156,7 @@
       client :post (u/join-path "auth/token/create" role-name)
       {:content-type :json
        :body (u/snakify-keys params)
-       :handle-response kebabify-body-auth}))
+       :handle-response u/kebabify-body-auth}))
 
 
   (lookup-token
@@ -197,21 +190,21 @@
         client :post "auth/token/renew"
         {:content-type :json
          :body (select-keys params [:token :increment])
-         :handle-response kebabify-body-auth})
+         :handle-response u/kebabify-body-auth})
 
       (:accessor params)
       (http/call-api
         client :post "auth/token/renew-accessor"
         {:content-type :json
          :body (select-keys params [:accessor :increment])
-         :handle-response kebabify-body-auth})
+         :handle-response u/kebabify-body-auth})
 
       :else
       (http/call-api
         client :post "auth/token/renew-self"
         {:content-type :json
          :body (select-keys params [:increment])
-         :handle-response kebabify-body-auth
+         :handle-response u/kebabify-body-auth
          :on-success (fn update-auth
                        [auth]
                        (proto/authenticate! client auth))})))

--- a/src/vault/auth/userpass.clj
+++ b/src/vault/auth/userpass.clj
@@ -1,0 +1,36 @@
+(ns vault.auth.userpass
+  "The /auth/userpass endpoint manages username & password authentication
+  functionality.
+
+  Reference: https://www.vaultproject.io/api-docs/auth/userpass"
+  (:require
+    [vault.client.http :as http]
+    [vault.client.proto :as proto]
+    [vault.util :as u])
+  (:import
+    vault.client.http.HTTPClient))
+
+
+(defprotocol API
+  "The userpass endpoints manage username & password authentication
+  functionality."
+
+  (login
+    [client username password]
+    "Login with the username and password."))
+
+
+(extend-type HTTPClient
+
+  API
+
+  (login
+    [client username password]
+    (http/call-api
+      client :post (u/join-path "auth/userpass/login/" username)
+      {:content-type :json
+       :body {:password password}
+       :handle-response u/kebabify-body-auth
+       :on-success (fn update-auth
+                     [auth]
+                     (proto/authenticate! client auth))})))

--- a/src/vault/auth/userpass.clj
+++ b/src/vault/auth/userpass.clj
@@ -28,7 +28,11 @@
 
   (login
     [client username password]
-    "Login with the username and password."))
+    "Login with the username and password. This method uses the
+    `/auth/userpass/login/:username` endpoint.
+
+    Returns the `auth` map from the login endpoint and also updates the auth
+    information in the client, including the new client token."))
 
 
 (extend-type HTTPClient

--- a/src/vault/util.clj
+++ b/src/vault/util.clj
@@ -56,6 +56,13 @@
   (walk-keys data kebab-keyword))
 
 
+(defn kebabify-body-auth
+  "Look up a map in the provided body under the `\"auth\"` key and kebabify
+  it."
+  [body]
+  (kebabify-keys (get body "auth")))
+
+
 (defn kebabify-body-data
   "Look up a map in the provided body under the `\"data\"` key and kebabify
   it."

--- a/test/vault/auth/userpass_test.clj
+++ b/test/vault/auth/userpass_test.clj
@@ -23,6 +23,7 @@
         (let [original-auth-info (vault/auth-info client)
               response (userpass/login client "foo" "bar")
               auth-info (vault/auth-info client)]
+          (is (nil? (::userpass/mount client)))
           (assert-authenticated-map response)
           (is (= (:client-token response)
                  (::auth/client-token auth-info)))
@@ -31,12 +32,9 @@
       (testing "with alternate mount"
         (cli "auth" "enable" "-path=auth-test" "userpass")
         (cli "write" "auth/auth-test/users/baz" "password=qux")
-        (let [original-auth-info (vault/auth-info client)
-              client' (userpass/with-mount client "auth-test")
-              response (userpass/login client' "baz" "qux")
-              auth-info (vault/auth-info client)]
+        (let [client' (userpass/with-mount client "auth-test")
+              response (userpass/login client' "baz" "qux")]
+          (is (= "auth-test" (::userpass/mount client')))
           (assert-authenticated-map response)
           (is (= (:client-token response)
-                 (::auth/client-token (vault/auth-info client))))
-          (is (not= (::auth/client-token original-auth-info)
-                    (::auth/client-token auth-info))))))))
+                 (::auth/client-token (vault/auth-info client')))))))))

--- a/test/vault/auth/userpass_test.clj
+++ b/test/vault/auth/userpass_test.clj
@@ -7,10 +7,19 @@
 
 (deftest ^:integration http-api
   (with-dev-server
-    (cli "auth" "enable" "userpass")
-    (cli "write" "auth/userpass/users/foo" "password=bar")
     (testing "login"
-      (let [auth (userpass/login client "foo" "bar")]
-        (is (string? (:accessor auth)))
-        (is (string? (:client-token auth)))
-        (is (pos-int? (:lease-duration auth)))))))
+      (testing "with default mount"
+        (cli "auth" "enable" "userpass")
+        (cli "write" "auth/userpass/users/foo" "password=bar")
+        (let [auth (userpass/login client "foo" "bar")]
+          (is (string? (:accessor auth)))
+          (is (string? (:client-token auth)))
+          (is (pos-int? (:lease-duration auth)))))
+      (testing "with alternate mount"
+        (cli "auth" "enable" "-path=auth-test" "userpass")
+        (cli "write" "auth/auth-test/users/baz" "password=qux")
+        (let [client' (userpass/with-mount client "auth-test")
+              auth (userpass/login client' "baz" "qux")]
+          (is (string? (:accessor auth)))
+          (is (string? (:client-token auth)))
+          (is (pos-int? (:lease-duration auth))))))))

--- a/test/vault/auth/userpass_test.clj
+++ b/test/vault/auth/userpass_test.clj
@@ -1,8 +1,17 @@
 (ns vault.auth.userpass-test
   (:require
     [clojure.test :refer [deftest is testing]]
+    [vault.auth :as auth]
     [vault.auth.userpass :as userpass]
+    [vault.client :as vault]
     [vault.integration :refer [with-dev-server cli]]))
+
+
+(defn- assert-authenticated-map
+  [auth]
+  (is (string? (:accessor auth)))
+  (is (string? (:client-token auth)))
+  (is (pos-int? (:lease-duration auth))))
 
 
 (deftest ^:integration http-api
@@ -11,15 +20,23 @@
       (testing "with default mount"
         (cli "auth" "enable" "userpass")
         (cli "write" "auth/userpass/users/foo" "password=bar")
-        (let [auth (userpass/login client "foo" "bar")]
-          (is (string? (:accessor auth)))
-          (is (string? (:client-token auth)))
-          (is (pos-int? (:lease-duration auth)))))
+        (let [original-auth-info (vault/auth-info client)
+              response (userpass/login client "foo" "bar")
+              auth-info (vault/auth-info client)]
+          (assert-authenticated-map response)
+          (is (= (:client-token response)
+                 (::auth/client-token auth-info)))
+          (is (not= (::auth/client-token original-auth-info)
+                    (::auth/client-token auth-info)))))
       (testing "with alternate mount"
         (cli "auth" "enable" "-path=auth-test" "userpass")
         (cli "write" "auth/auth-test/users/baz" "password=qux")
-        (let [client' (userpass/with-mount client "auth-test")
-              auth (userpass/login client' "baz" "qux")]
-          (is (string? (:accessor auth)))
-          (is (string? (:client-token auth)))
-          (is (pos-int? (:lease-duration auth))))))))
+        (let [original-auth-info (vault/auth-info client)
+              client' (userpass/with-mount client "auth-test")
+              response (userpass/login client' "baz" "qux")
+              auth-info (vault/auth-info client)]
+          (assert-authenticated-map response)
+          (is (= (:client-token response)
+                 (::auth/client-token (vault/auth-info client))))
+          (is (not= (::auth/client-token original-auth-info)
+                    (::auth/client-token auth-info))))))))

--- a/test/vault/auth/userpass_test.clj
+++ b/test/vault/auth/userpass_test.clj
@@ -1,0 +1,16 @@
+(ns vault.auth.userpass-test
+  (:require
+    [clojure.test :refer [deftest is testing]]
+    [vault.auth.userpass :as userpass]
+    [vault.integration :refer [with-dev-server cli]]))
+
+
+(deftest ^:integration http-api
+  (with-dev-server
+    (cli "auth" "enable" "userpass")
+    (cli "write" "auth/userpass/users/foo" "password=bar")
+    (testing "login"
+      (let [auth (userpass/login client "foo" "bar")]
+        (is (string? (:accessor auth)))
+        (is (string? (:client-token auth)))
+        (is (pos-int? (:lease-duration auth)))))))


### PR DESCRIPTION
Implemented the [Userpass](https://www.vaultproject.io/api-docs/auth/userpass)'s `login` method. Validated with the added integration test for userpass.

This should resolve https://github.com/amperity/vault-clj/issues/78.