### PR TITLE
Bump clj-kondo to latest version.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,9 +47,9 @@ jobs:
       - run:
           name: Install clj-kondo
           environment:
-            CLJ_KONDO_VERSION: 2021.08.06
+            CLJ_KONDO_VERSION: 2022.09.08
           command: |
-            wget https://github.com/borkdude/clj-kondo/releases/download/v${CLJ_KONDO_VERSION}/clj-kondo-${CLJ_KONDO_VERSION}-linux-amd64.zip
+            wget https://github.com/clj-kondo/clj-kondo/releases/download/v${CLJ_KONDO_VERSION}/clj-kondo-${CLJ_KONDO_VERSION}-linux-amd64.zip
             unzip clj-kondo-${CLJ_KONDO_VERSION}-linux-amd64.zip
       - run:
           name: Lint source code


### PR DESCRIPTION
clj-kondo also lives in the [clj-kondo](https://github.com/clj-kondo) organization now, not under [borkdude](https://github.com/borkdude)'s account. This should resolve the linting failures due to unrecognized functions from Clojure v1.11 (see those failures [here](https://github.com/amperity/vault-clj/pull/87#issuecomment-1264250542)).