### PR TITLE
Add GitHub auth method.

### DIFF
--- a/src/vault/auth/github.clj
+++ b/src/vault/auth/github.clj
@@ -1,0 +1,58 @@
+(ns vault.auth.github
+  "The /auth/github endpoint manages GitHub authentication functionality.
+
+  Reference: https://www.vaultproject.io/api-docs/auth/github"
+  (:require
+    [vault.client.http :as http]
+    [vault.client.proto :as proto]
+    [vault.util :as u])
+  (:import
+    vault.client.http.HTTPClient))
+
+
+(def default-mount
+  "Default mount point to use if one is not provided."
+  "github")
+
+
+(defprotocol API
+  "The GitHub auth endpoints manage GitHub authentication functionality."
+
+  (with-mount
+    [client mount]
+    "Return an updated client which will resolve calls against the provided
+    mount instead of the default. Passing `nil` will reset the client to the
+    default.")
+
+  (login
+    [client token]
+    "Login using a GitHub access token. This method uses the
+    `/auth/github/login` endpoint.
+
+    Returns the `auth` map from the login endpoint and also updates the auth
+    information in the client, including the new client token."))
+
+
+(extend-type HTTPClient
+
+  API
+
+  (with-mount
+    [client mount]
+    (if (some? mount)
+      (assoc client ::mount mount)
+      (dissoc client ::mount)))
+
+
+  (login
+    [client token]
+    (let [mount (::mount client default-mount)
+          api-path (u/join-path "auth" mount "login")]
+      (http/call-api
+        client :post api-path
+        {:content-type :json
+         :body {:token token}
+         :handle-response u/kebabify-body-auth
+         :on-success (fn update-auth
+                       [auth]
+                       (proto/authenticate! client auth))}))))

--- a/test/vault/auth/github_test.clj
+++ b/test/vault/auth/github_test.clj
@@ -1,0 +1,12 @@
+(ns vault.auth.github-test
+  (:require
+    [clojure.test :refer [deftest is testing]]
+    [vault.auth.github :as github]
+    [vault.client.http :as http]))
+
+
+(deftest with-mount
+  (testing "different mounts"
+    (let [client (http/http-client "https://foo.com")]
+      (is (nil? (::github/mount client)))
+      (is (= "test-mount" (::github/mount (github/with-mount client "test-mount")))))))


### PR DESCRIPTION
Implemented the [GitHub](https://www.vaultproject.io/api-docs/auth/github) auth's [login](https://www.vaultproject.io/api-docs/auth/github#login) method. This should resolve https://github.com/amperity/vault-clj/issues/79.

Validated with a local vault server and my personal Github token, using the Amperity organization. I figured it probably didn't  make sense to have an integration test for this, but I'm open to ideas for how to durably test this.

Validation steps:

- In the terminal:
```shell
❯ vault auth enable -path=test-mount github
Success! Enabled github auth method at: test-mount/

❯ vault write auth/test-mount/config organization=amperity
Success! Data written to: auth/test-mount/config

❯ vault write auth/test-mount/map/teams/developers value=default
Success! Data written to: auth/test-mount/map/teams/developers
```

- In the REPL:
```clojure
vault.repl=> (def client (http/http-client "http://127.0.0.1:8200"))
#'vault.repl/client

vault.repl=> (require '[vault.auth.github :as gh])
nil

vault.repl=> (gh/login (gh/with-mount client "test-mount") "<redacted>")
{:accessor "<redacted>",
 :client-token "<redacted>",
 :entity-id "<redacted>",
 :lease-duration 2764800,
 :metadata {:org "amperity", :username "brendonjwong"},
 :mfa-requirement nil,
 :num-uses 0,
 :orphan true,
 :policies ["default"],
 :renewable true,
 :token-policies ["default"],
 :token-type "service"}
```