### PR TITLE
Add Kubernetes auth method

### DIFF
--- a/src/vault/auth/kubernetes.clj
+++ b/src/vault/auth/kubernetes.clj
@@ -26,15 +26,10 @@
     default.")
 
   (login
-    [client params]
-    "Login to the provided role using a JWT. This method uses the
+    [client role jwt]
+    "Login to the provided role using a signed JSON Web Token (JWT) for
+    authenticating a service account. This method uses the
     `/auth/kubernetes/login` endpoint.
-
-    Parameters must include:
-    - `:role`
-      Name of the role against which the login is being attempted.
-    - `:jwt`
-      Signed JSON Web Token (JWT) for authenticating a service account.
 
     Returns the `auth` map from the login endpoint and also updates the auth
     information in the client, including the new client token."))
@@ -52,11 +47,7 @@
 
 
   (login
-    [client {:keys [jwt role]}]
-    (when-not jwt
-      (throw (IllegalArgumentException. "Kubernetes auth params must include :jwt")))
-    (when-not role
-      (throw (IllegalArgumentException. "Kubernetes auth params must include :role")))
+    [client role jwt]
     (let [mount (::mount client default-mount)
           api-path (u/join-path "auth" mount "login")]
       (http/call-api

--- a/src/vault/auth/kubernetes.clj
+++ b/src/vault/auth/kubernetes.clj
@@ -1,0 +1,69 @@
+(ns vault.auth.kubernetes
+  "The /auth/kubernetes endpoint manages Kubernetes authentication
+  functionality.
+
+  Reference: https://www.vaultproject.io/api-docs/auth/kubernetes"
+  (:require
+    [vault.client.http :as http]
+    [vault.client.proto :as proto]
+    [vault.util :as u])
+  (:import
+    vault.client.http.HTTPClient))
+
+
+(def default-mount
+  "Default mount point to use if one is not provided."
+  "kubernetes")
+
+
+(defprotocol API
+  "The Kubernetes endpoints manage Kubernetes authentication functionality."
+
+  (with-mount
+    [client mount]
+    "Return an updated client which will resolve calls against the provided
+    mount instead of the default. Passing `nil` will reset the client to the
+    default.")
+
+  (login
+    [client params]
+    "Login to the provided role using a JWT. This method uses the
+    `/auth/kubernetes/login` endpoint.
+
+    Parameters must include:
+    - `:role`
+      Name of the role against which the login is being attempted.
+    - `:jwt`
+      Signed JSON Web Token (JWT) for authenticating a service account.
+
+    Returns the `auth` map from the login endpoint and also updates the auth
+    information in the client, including the new client token."))
+
+
+(extend-type HTTPClient
+
+  API
+
+  (with-mount
+    [client mount]
+    (if (some? mount)
+      (assoc client ::mount mount)
+      (dissoc client ::mount)))
+
+
+  (login
+    [client {:keys [jwt role]}]
+    (when-not jwt
+      (throw (IllegalArgumentException. "Kubernetes auth params must include :jwt")))
+    (when-not role
+      (throw (IllegalArgumentException. "Kubernetes auth params must include :role")))
+    (let [mount (::mount client default-mount)
+          api-path (u/join-path "auth" mount "login")]
+      (http/call-api
+        client :post api-path
+        {:content-type :json
+         :body {:jwt jwt :role role}
+         :handle-response u/kebabify-body-auth
+         :on-success (fn update-auth
+                       [auth]
+                       (proto/authenticate! client auth))}))))

--- a/test/vault/auth/kubernetes_test.clj
+++ b/test/vault/auth/kubernetes_test.clj
@@ -1,0 +1,29 @@
+(ns vault.auth.kubernetes-test
+  (:require
+    [clojure.test :refer [deftest is testing]]
+    [vault.auth.kubernetes :as k8s]
+    [vault.client.http :as http]))
+
+
+(deftest with-mount
+  (testing "different mounts"
+    (let [client (http/http-client "https://foo.com")]
+      (is (nil? (::k8s/mount client)))
+      (is (= "test-mount" (::k8s/mount (k8s/with-mount client "test-mount")))))))
+
+
+(deftest login
+  (testing "should throw an exception if jwt or role is missing from the params"
+    (let [client (http/http-client "https://foo.com")]
+      (is (thrown-with-msg?
+            IllegalArgumentException
+            #"Kubernetes auth params must include :jwt"
+            (k8s/login client {})))
+      (is (thrown-with-msg?
+            IllegalArgumentException
+            #"Kubernetes auth params must include :jwt"
+            (k8s/login client {:role "dev"})))
+      (is (thrown-with-msg?
+            IllegalArgumentException
+            #"Kubernetes auth params must include :role"
+            (k8s/login client {:jwt "eyJhfoo"}))))))

--- a/test/vault/auth/kubernetes_test.clj
+++ b/test/vault/auth/kubernetes_test.clj
@@ -10,20 +10,3 @@
     (let [client (http/http-client "https://foo.com")]
       (is (nil? (::k8s/mount client)))
       (is (= "test-mount" (::k8s/mount (k8s/with-mount client "test-mount")))))))
-
-
-(deftest login
-  (testing "should throw an exception if jwt or role is missing from the params"
-    (let [client (http/http-client "https://foo.com")]
-      (is (thrown-with-msg?
-            IllegalArgumentException
-            #"Kubernetes auth params must include :jwt"
-            (k8s/login client {})))
-      (is (thrown-with-msg?
-            IllegalArgumentException
-            #"Kubernetes auth params must include :jwt"
-            (k8s/login client {:role "dev"})))
-      (is (thrown-with-msg?
-            IllegalArgumentException
-            #"Kubernetes auth params must include :role"
-            (k8s/login client {:jwt "eyJhfoo"}))))))


### PR DESCRIPTION
Implemented the [Kubernetes](https://www.vaultproject.io/api-docs/auth/kubernetes) auth's [login](https://www.vaultproject.io/api-docs/auth/kubernetes#login) method. This should resolve https://github.com/amperity/vault-clj/issues/81.

Similar to https://github.com/amperity/vault-clj/pull/89, I'm not sure it makes sense to write an integration test for this just yet due to the amount of setup it requires, but it's not impossible either. I did run a K8s cluster locally, configured to use my local Vault server and was able to validate the login method using a JWT from a local K8s service account.

Steps to validate:
1. Follow all the steps in https://learn.hashicorp.com/tutorials/vault/kubernetes-external-vault
    - Instead of starting a vault server how they suggest, I modified `dev/server` to run the Vault server at `http://0.0.0.0:8200` with the token `root` and then started the server by calling `dev/server`.
1. Get the JWT from the service account with `kubectl create token internal-app`
1. Login with the REPL:

    ```clojure
    vault.repl=> (def client (http/http-client "http://0.0.0.0:8200"))
    #'vault.repl/client
    
    vault.repl=> (require '[vault.auth.kubernetes :as k8s])
    nil
    
    vault.repl=> (k8s/login client {:role "devweb-app" :jwt "<jwt>"})
    {:accessor "<redacted>",
     :client-token "<redacted>",
     :entity-id "<redacted>",
     :lease-duration 86400,
     :metadata {:role "devweb-app",
                :service-account-name "internal-app",
                :service-account-namespace "default",
                :service-account-secret-name "",
                :service-account-uid "7a994837-1605-48ca-9aa6-f314d311e0a7"},
     :mfa-requirement nil,
     :num-uses 0,
     :orphan true,
     :policies ["default" "devwebapp"],
     :renewable true,
     :token-policies ["default" "devwebapp"],
     :token-type "service"}
    ```
