### PR TITLE
add approle login functionality

### DIFF
--- a/dev/vault/repl.clj
+++ b/dev/vault/repl.clj
@@ -6,6 +6,7 @@
     [clojure.string :as str]
     [clojure.tools.namespace.repl :refer [refresh]]
     [vault.auth :as auth]
+    [vault.auth.approle :as auth.approle]
     [vault.auth.token :as auth.token]
     [vault.auth.userpass :as auth.userpass]
     [vault.client :as vault]

--- a/src/vault/auth/approle.clj
+++ b/src/vault/auth/approle.clj
@@ -1,0 +1,59 @@
+(ns vault.auth.approle
+  "The /auth/approle endpoint manages approle role-id & secret-id authentication functionality.
+
+  Reference: https://www.vaultproject.io/api-docs/auth/approle"
+  (:require
+    [vault.client.http :as http]
+    [vault.client.proto :as proto]
+    [vault.util :as u])
+  (:import
+    vault.client.http.HTTPClient))
+
+
+(def default-mount
+  "Default mount point to use if one is not provided."
+  "approle")
+
+
+(defprotocol API
+  "The AppRole auth endpoints manage role_id and secret_id authentication"
+
+  (with-mount
+    [client mount]
+    "Return an updated client which will resolve calls against the provided
+    mount instead of the default. Passing `nil` will reset the client to the
+    default.")
+
+  (login
+    [client role-id secret-id]
+    "Login using an AppRole role_id and secret_id.
+    This method uses the `/auth/approle/login` endpoint.
+
+    Returns the `auth` map from the login endpoint and also updates the auth
+    information in the client, including the new client token."))
+
+
+(extend-type HTTPClient
+
+  API
+
+  (with-mount
+    [client mount]
+    (if (some? mount)
+      (assoc client ::mount mount)
+      (dissoc client ::mount)))
+
+
+  (login
+    [client role-id secret-id]
+    (let [mount (::mount client default-mount)
+          api-path (u/join-path "auth" mount "login")]
+      (http/call-api
+        client :post api-path
+        {:content-type :json
+         :body {:role_id role-id
+                :secret_id secret-id}
+         :handle-response u/kebabify-body-auth
+         :on-success (fn update-auth
+                       [auth]
+                       (proto/authenticate! client auth))}))))

--- a/test/vault/auth/approle_test.clj
+++ b/test/vault/auth/approle_test.clj
@@ -1,0 +1,60 @@
+(ns vault.auth.approle-test
+  (:require
+    [clojure.data.json :as json]
+    [clojure.test :refer [deftest is testing]]
+    [vault.auth :as auth]
+    [vault.auth.approle :as approle]
+    [vault.client :as vault]
+    [vault.integration :refer [with-dev-server cli]]))
+
+
+(defn- assert-authenticated-map
+  [auth]
+  (is (boolean? (:renewable auth)))
+  (is (pos-int? (:lease-duration auth)))
+  (is (string? (:accessor auth)))
+  (is (string? (:client-token auth)))
+  (is (map? (:metadata auth)))
+  (is (coll? (:token-policies auth))))
+
+
+(deftest ^:integration http-api
+  (with-dev-server
+    (testing "login"
+      (testing "with default mount"
+        (cli "auth" "enable" "approle")
+        (cli "write" "auth/approle/role/foo" "secret_id_ttl=1m")
+        (let [role-id  (-> (cli "read" "auth/approle/role/foo/role-id")
+                           (json/read-str)
+                           (get-in ["data" "role_id"]))
+              secret-id (-> (cli "write" "-f" "auth/approle/role/foo/secret-id")
+                            (json/read-str)
+                            (get-in ["data" "secret_id"]))
+              original-auth-info (vault/auth-info client)
+              response (approle/login client role-id secret-id)
+              auth-info (vault/auth-info client)]
+          (is (nil? (::approle/mount client)))
+          (assert-authenticated-map response)
+          (is (= (:client-token response)
+                 (::auth/client-token auth-info)))
+          (is (not= (::auth/client-token original-auth-info)
+                    (::auth/client-token auth-info)))))
+      (testing "with alternate mount"
+        (cli "auth" "enable" "-path=auth-test" "approle")
+        (cli "write" "auth/auth-test/role/bar" "secret_id_ttl=1m")
+        (let [client' (approle/with-mount client "auth-test")
+              role-id  (-> (cli "read" "auth/auth-test/role/bar/role-id")
+                           (json/read-str)
+                           (get-in ["data" "role_id"]))
+              secret-id (-> (cli "write" "-f" "auth/auth-test/role/bar/secret-id")
+                            (json/read-str)
+                            (get-in ["data" "secret_id"]))
+              original-auth-info (vault/auth-info client')
+              response (approle/login client' role-id secret-id)
+              auth-info (vault/auth-info client')]
+          (is (= "auth-test" (::approle/mount client')))
+          (assert-authenticated-map response)
+          (is (= (:client-token response)
+                 (::auth/client-token auth-info)))
+          (is (not= (::auth/client-token original-auth-info)
+                    (::auth/client-token auth-info))))))))


### PR DESCRIPTION
This should add in support for the [AppRole](https://www.vaultproject.io/api-docs/auth/approle#login-with-approle) `login` function.

I based a majority of the changes off of stuff I saw in the other auth implementations.

With this, Issue #75  should be done. Once this has a ✅ I will go ahead and tackle one of the more complicated issues.