### PR TITLE
Remove automatic 5xx retries in the HTTP client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ This change log follows the conventions of [keepachangelog.com](http://keepachan
 
 ## [Unreleased]
 
-...
+### Changed
+- The default logic in the HTTP client no longer automatically retries 5xx
+  responses; this needs to be handled by the control flow to avoid blocking
+  http-kit's callback thread.
 
 
 ## [2.0.560] - 2023-09-08

--- a/src/vault/client/http.clj
+++ b/src/vault/client/http.clj
@@ -125,7 +125,7 @@
 
             (callback
               [{:keys [opts status headers body error]}]
-              (let [{::keys [state redirects retries]} opts]
+              (let [{::keys [state redirects]} opts]
                 (try
                   (if error
                     ;; TODO: shape exception?
@@ -169,15 +169,6 @@
                              ::redirects (inc redirects)
                              :url location})))
 
-                      ;; Retry some network errors
-                      (and (<= 502 status 504)
-                           (< retries 2))
-                      (do
-                        (Thread/sleep 500)
-                        (make-request
-                          {::state state
-                           ::retries (inc retries)}))
-
                       ;; Otherwise, this was a failure response.
                       :else
                       (let [handle-error (:handle-error params identity)
@@ -198,8 +189,7 @@
         (fn call
           [state]
           (make-request {::state state
-                         ::redirects 0
-                         ::retries 0}))))))
+                         ::redirects 0}))))))
 
 
 (defn ^:no-doc cached-response


### PR DESCRIPTION
As I was building out a control flow handler in our main codebase, I realized that the automatic retries in the HTTP client code are problematic for a few reasons:

1. Clients can't configure the behavior or wait time because it's hard-coded.
2. Using `Thread/sleep` directly will block `http-kit`'s callback thread and doesn't mix well with an async flow model.
3. The control flow can't see these, so it can't annotate an observability span with the failure info.

I concluded that the best thing to do here is to remove the automatic retries and leave it to the control flow to handle.