### PR TITLE
Client observability info threading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,14 @@ This change log follows the conventions of [keepachangelog.com](http://keepachan
 
 ## [Unreleased]
 
-...
+### Changed
+- The way the client handles "meta info" has changed to become more
+  comprehensive, to reduce repetition and ensure the info is available to
+  the flow controller.
+
+### Added
+- The `kv.v1` and `kv.v2` secret engines attach metadata to `:not-found` values
+  if they support metadata, similar to normal responses.
 
 
 ## [2.0.560] - 2023-09-08

--- a/src/vault/auth/approle.clj
+++ b/src/vault/auth/approle.clj
@@ -124,7 +124,8 @@
           api-path (u/join-path "auth" mount "role" role-name)]
       (http/call-api
         client :post api-path
-        {:content-type :json
+        {:info {::mount mount, ::role role-name}
+         :content-type :json
          :body (-> opts
                    (select-keys [:bind-secret-id
                                  :secret-id-bound-cidrs
@@ -149,7 +150,8 @@
           api-path (u/join-path "auth" mount "role")]
       (http/call-api
         client :list api-path
-        {:handle-response u/kebabify-body-data})))
+        {:info {::mount mount}
+         :handle-response u/kebabify-body-data})))
 
 
   (read-role
@@ -158,7 +160,8 @@
           api-path (u/join-path "auth" mount "role" role-name)]
       (http/call-api
         client :get api-path
-        {:handle-response u/kebabify-body-data})))
+        {:info {::mount mount, ::role role-name}
+         :handle-response u/kebabify-body-data})))
 
 
   (read-role-id
@@ -167,7 +170,8 @@
           api-path (u/join-path "auth" mount "role" role-name "role-id")]
       (http/call-api
         client :get api-path
-        {:handle-response u/kebabify-body-data})))
+        {:info {::mount mount, ::role role-name}
+         :handle-response u/kebabify-body-data})))
 
 
   (generate-secret-id!
@@ -178,7 +182,8 @@
            api-path (u/join-path "auth" mount "role" role-name "secret-id")]
        (http/call-api
          client :post api-path
-         {:content-type :json
+         {:info {::mount mount, ::role role-name}
+          :content-type :json
           :body (-> opts
                     (select-keys [:metadata
                                   :cidr-list
@@ -193,7 +198,8 @@
           api-path (u/join-path "auth" mount "login")]
       (http/call-api
         client :post api-path
-        {:content-type :json
+        {:info {::mount mount}
+         :content-type :json
          :body {:role_id role-id
                 :secret_id secret-id}
          :handle-response u/kebabify-body-auth

--- a/src/vault/auth/github.clj
+++ b/src/vault/auth/github.clj
@@ -50,7 +50,8 @@
           api-path (u/join-path "auth" mount "login")]
       (http/call-api
         client :post api-path
-        {:content-type :json
+        {:info {::mount mount}
+         :content-type :json
          :body {:token token}
          :handle-response u/kebabify-body-auth
          :on-success (fn update-auth

--- a/src/vault/auth/kubernetes.clj
+++ b/src/vault/auth/kubernetes.clj
@@ -52,7 +52,8 @@
           api-path (u/join-path "auth" mount "login")]
       (http/call-api
         client :post api-path
-        {:content-type :json
+        {:info {::mount mount, ::role role}
+         :content-type :json
          :body {:jwt jwt :role role}
          :handle-response u/kebabify-body-auth
          :on-success (fn update-auth

--- a/src/vault/auth/ldap.clj
+++ b/src/vault/auth/ldap.clj
@@ -51,7 +51,8 @@
           api-path (u/join-path "auth" mount "login" username)]
       (http/call-api
         client :post api-path
-        {:content-type :json
+        {:info {::mount mount, ::username username}
+         :content-type :json
          :body {:password password}
          :handle-response u/kebabify-body-auth
          :on-success (fn update-auth

--- a/src/vault/auth/userpass.clj
+++ b/src/vault/auth/userpass.clj
@@ -52,7 +52,8 @@
           api-path (u/join-path "auth" mount "login" username)]
       (http/call-api
         client :post api-path
-        {:content-type :json
+        {:info {::mount mount, ::username username}
+         :content-type :json
          :body {:password password}
          :handle-response u/kebabify-body-auth
          :on-success (fn update-auth

--- a/src/vault/secret/aws.clj
+++ b/src/vault/secret/aws.clj
@@ -104,13 +104,11 @@
            api-path (u/join-path mount "creds" user-name)
            cache-key [::user mount user-name]]
        (http/generate-rotatable-credentials!
-         client
-         {:http-method :get
-          :api-path api-path
+         client :get api-path
+         {:info {::mount mount, ::user user-name}
           :cache-key cache-key}
-         (assoc opts
-                :response-additional-meta {::mount mount
-                                           ::user user-name})))))
+         opts))))
+
 
   (generate-role-credentials!
     ([client role-name]
@@ -120,12 +118,9 @@
            api-path (u/join-path mount "sts" role-name)
            cache-key [::role mount role-name]]
        (http/generate-rotatable-credentials!
-         client
-         {:http-method :get
-          :api-path api-path
+         client :get api-path
+         {:info {::mount mount, ::role role-name}
           :cache-key cache-key}
          (assoc opts
                 ;; STS credentials are not renewable
-                :renew? false
-                :response-additional-meta {::mount mount
-                                           ::role role-name}))))))
+                :renew? false))))))

--- a/src/vault/secret/database.clj
+++ b/src/vault/secret/database.clj
@@ -84,10 +84,7 @@
            api-path (u/join-path mount "creds" role-name)
            cache-key [::role mount role-name]]
        (http/generate-rotatable-credentials!
-         client
-         {:http-method :get
-          :api-path api-path
+         client :get api-path
+         {:info {::mount mount, ::role role-name}
           :cache-key cache-key}
-         (assoc opts
-                :response-additional-meta {::mount mount
-                                           ::role role-name}))))))
+         opts)))))

--- a/src/vault/secret/transit.clj
+++ b/src/vault/secret/transit.clj
@@ -147,15 +147,16 @@
       (assoc client ::mount mount)
       (dissoc client ::mount)))
 
+
   (read-key
     [client key-name]
     (let [mount (::mount client default-mount)]
       (http/call-api
         client :get (u/join-path mount "keys" key-name)
-        {:content-type :json
-         :handle-response (fn handle-response
-                            [body]
-                            (u/kebabify-keys (get body "data")))})))
+        {::info {::mount mount, ::key key-name}
+         :content-type :json
+         :handle-response u/kebabify-body-data})))
+
 
   (rotate-key!
     ([client key-name]
@@ -164,16 +165,20 @@
      (let [mount (::mount client default-mount)]
        (http/call-api
          client :post (u/join-path mount "keys" key-name "rotate")
-         {:content-type :json
+         {:info {::mount mount, ::key key-name}
+          :content-type :json
           :body opts}))))
+
 
   (update-key-configuration!
     [client key-name opts]
     (let [mount (::mount client default-mount)]
       (http/call-api
         client :post (u/join-path mount "keys" key-name "config")
-        {:content-type :json
+        {:info {::mount mount, ::key key-name}
+         :content-type :json
          :body opts})))
+
 
   (encrypt-data!
     ([client key-name plaintext]
@@ -182,11 +187,11 @@
      (let [mount (::mount client default-mount)]
        (http/call-api
          client :post (u/join-path mount "encrypt" key-name)
-         {:content-type :json
+         {:info {::mount mount, ::key key-name}
+          :content-type :json
           :body (assoc opts :plaintext plaintext)
-          :handle-response (fn handle-response
-                             [body]
-                             (u/kebabify-keys (get body "data")))}))))
+          :handle-response u/kebabify-body-data}))))
+
 
   (decrypt-data!
     ([client key-name ciphertext]
@@ -195,8 +200,7 @@
      (let [mount (::mount client default-mount)]
        (http/call-api
          client :post (u/join-path mount "decrypt" key-name)
-         {:content-type :json
+         {:info {::mount mount, ::key key-name}
+          :content-type :json
           :body (u/stringify-keys (assoc opts :ciphertext ciphertext))
-          :handle-response (fn handle-response
-                             [body]
-                             (u/kebabify-keys (get body "data")))})))))
+          :handle-response u/kebabify-body-data})))))

--- a/src/vault/sys/auth.clj
+++ b/src/vault/sys/auth.clj
@@ -120,7 +120,8 @@
     [client path params]
     (http/call-api
       client :post (u/join-path "sys/auth" path)
-      {:content-type :json
+      {:info {::path path, ::type (:type params)}
+       :content-type :json
        :body (u/snakify-keys params)}))
 
 
@@ -128,19 +129,21 @@
     [client path]
     (http/call-api
       client :delete (u/join-path "sys/auth" path)
-      {}))
+      {:info {::path path}}))
 
 
   (read-method-tuning
     [client path]
     (http/call-api
       client :get (u/join-path "sys/auth" path "tune")
-      {:handle-response u/kebabify-body-data}))
+      {:info {::path path}
+       :handle-response u/kebabify-body-data}))
 
 
   (tune-method!
     [client path params]
     (http/call-api
       client :post (u/join-path "sys/auth" path "tune")
-      {:content-type :json
+      {:info {::path path}
+       :content-type :json
        :body (u/snakify-keys params)})))

--- a/src/vault/sys/leases.clj
+++ b/src/vault/sys/leases.clj
@@ -45,7 +45,8 @@
     [client lease-id]
     (http/call-api
       client :put "sys/leases/lookup"
-      {:content-type :json
+      {:info {::lease/id lease-id}
+       :content-type :json
        :body {:lease_id lease-id}}))
 
 
@@ -53,7 +54,7 @@
     [client prefix]
     (http/call-api
       client :list (u/join-path "sys/leases/lookup" prefix)
-      {}))
+      {:info {::prefix prefix}}))
 
 
   (renew-lease!
@@ -62,7 +63,8 @@
     ([client lease-id increment]
      (http/call-api
        client :put "sys/leases/renew"
-       {:content-type :json
+       {:info {::lease/id lease-id}
+        :content-type :json
         :body (cond-> {:lease_id lease-id}
                 increment
                 (assoc :increment increment))
@@ -77,5 +79,6 @@
     (lease/delete! (:leases client) lease-id)
     (http/call-api
       client :put "sys/leases/revoke"
-      {:content-type :json
+      {:info {::lease/id lease-id}
+       :content-type :json
        :body {:lease_id lease-id}})))

--- a/src/vault/sys/mounts.clj
+++ b/src/vault/sys/mounts.clj
@@ -81,7 +81,8 @@
     [client path params]
     (http/call-api
       client :post (u/join-path "sys/mounts" path)
-      {:content-type :json
+      {:info {::path path, ::type (:type params)}
+       :content-type :json
        :body (u/snakify-keys params)}))
 
 
@@ -89,26 +90,29 @@
     [client path]
     (http/call-api
       client :delete (u/join-path "sys/mounts" path)
-      {}))
+      {:info {::path path}}))
 
 
   (read-secrets-configuration
     [client path]
     (http/call-api
       client :get (u/join-path "sys/mounts" path)
-      {:handle-response u/kebabify-body-data}))
+      {:info {::path path}
+       :handle-response u/kebabify-body-data}))
 
 
   (read-mount-configuration
     [client path]
     (http/call-api
       client :get (u/join-path "sys/mounts" path "tune")
-      {:handle-response u/kebabify-body-data}))
+      {:info {::path path}
+       :handle-response u/kebabify-body-data}))
 
 
   (tune-mount-configuration!
     [client path params]
     (http/call-api
       client :post (u/join-path "sys/mounts" path "tune")
-      {:content-type :json
+      {:info {::path path}
+       :content-type :json
        :body (u/snakify-keys params)})))


### PR DESCRIPTION
Further changes in response to building out a new control-flow handler - this time focused on how the request metadata is supplied to the flow handler as well as how it's attached to responses.

The `flow/call` method already accepted an `info` argument, but there was no way for each implementation to feed data into that through the HTTP client. Now the `http/call-api` function accepts `:info` as part of the request parameters, which is threaded through the whole call chain. The client also does more work to ensure that gets included in response metadata or exception data, so that the API implementations don't need to worry about that.

I tested this by building out a really simple flow handler which logs/prints the captured metadata, then called some `kv2` operations:

```clojure
vault.repl=> (kv2/read-secret client "foo/bar/bax")
;; 20:22:43.872 [client-worker-2]        ERROR vault.client.flow               Request failed in 8.2 ms
;; Execution error (ExceptionInfo) at vault.secret.kv.v2/ex-not-found (v2.clj:182).
;; No kv-v2 secret found at secret:foo/bar/bax
{:vault.client/elapsed 8.241542,
 :vault.client/method :get,
 :vault.client/path "secret/data/foo/bar/bax",
 :vault.client/status 404,
 :vault.secret.kv.v2/mount "secret",
 :vault.secret.kv.v2/path "foo/bar/bax"}

vault.repl=> (do (kv2/read-secret client "foo/bar/baz") nil)
;; 20:22:56.982 [client-worker-3]        INFO  vault.client.flow               Request suceeded in 2.4 ms
nil
{:vault.client/elapsed 2.404,
 :vault.client/method :get,
 :vault.client/path "secret/data/foo/bar/baz",
 :vault.client/request-id "00ea31c9-fc9a-6ed2-28d5-85130524cfd7",
 :vault.client/status 200,
 :vault.secret.kv.v2/created-time #<java.time.Instant@4457761b 2023-09-13T18:41:20.463172Z>,
 :vault.secret.kv.v2/custom-metadata nil,
 :vault.secret.kv.v2/destroyed false,
 :vault.secret.kv.v2/mount "secret",
 :vault.secret.kv.v2/path "foo/bar/baz",
 :vault.secret.kv.v2/version 1}
```
This intentionally excludes the request query and response headers for brevity, though they are present in the metadata.