### PR TITLE
Transit engine polish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ commands:
       - run:
           name: Install vault
           environment:
-            VAULT_VERSION: 1.11.4
+            VAULT_VERSION: 1.14.0
           command: |
             wget https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip
             unzip vault_${VAULT_VERSION}_linux_amd64.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ should be minor.
 - `vault.client/config-client` accepts options for configuring the Vault
   client, as in `new-client`.
 
+### Removed
+- Removed the unused `vault.util/sha-256` function.
+
 
 ## [2.0.560] - 2023-09-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This change log follows the conventions of [keepachangelog.com](http://keepachan
 
 ## [Unreleased]
 
+This release contains a number of potentially breaking changes, though they
+should be minor.
+
 ### Changed
 - The default logic in the HTTP client no longer automatically retries 5xx
   responses; this needs to be handled by the control flow to avoid blocking
@@ -16,6 +19,15 @@ This change log follows the conventions of [keepachangelog.com](http://keepachan
   the flow controller.
   [#102](https://github.com/amperity/vault-clj/pull/102)
 - `vault.client/config-wrapped-client` renamed to `unwrap-client`.
+- The transit engine automatically base64-encodes inputs where necessary,
+  accepting both strings and bytes. Similarly, it will decode the decryption
+  results from base64 back into strings or bytes.
+- Batch-mode encryption and decryption in the transit engine is simpler to do
+  and based off the type of the input data argument.
+
+### Fixed
+- Several response shapes from the transit engine methods are correctly coerced
+  now.
 
 ### Added
 - The `kv.v1` and `kv.v2` secret engines attach metadata to `:not-found` values

--- a/dev/vault/repl.clj
+++ b/dev/vault/repl.clj
@@ -18,6 +18,7 @@
     [vault.secret.database :as database]
     [vault.secret.kv.v1 :as kv1]
     [vault.secret.kv.v2 :as kv2]
+    [vault.secret.transit :as transit]
     [vault.sys.auth :as sys.auth]
     [vault.sys.health :as sys.health]
     [vault.util :as u]))

--- a/doc/cljdoc.edn
+++ b/doc/cljdoc.edn
@@ -1,7 +1,7 @@
 {:cljdoc/languages ["clj"]
  :cljdoc.doc/tree
  [["Readme" {:file "README.md"}]
-  ["Changes" {:file "CHANGELOG.md"}]
   ["Control Flow" {:file "doc/control-flow.md"}]
   ["Local Development" {:file "doc/development.md"}]
-  ["Upgrading from 1.x" {:file "doc/upgrading-1x.md"}]]}
+  ["Upgrading from 1.x" {:file "doc/upgrading-1x.md"}]
+  ["Changes" {:file "CHANGELOG.md"}]]}

--- a/src/vault/util.clj
+++ b/src/vault/util.clj
@@ -4,7 +4,6 @@
     [clojure.string :as str]
     [clojure.walk :as walk])
   (:import
-    java.security.MessageDigest
     java.time.Instant
     java.util.Base64))
 
@@ -158,16 +157,6 @@
      (if as-string?
        (String. bs "UTF-8")
        bs))))
-
-
-(defn sha-256
-  "Hash string data with the SHA-2 256 bit algorithm. Returns the digest as a
-  hex string."
-  [s]
-  (let [hasher (MessageDigest/getInstance "SHA-256")
-        str-bytes (.getBytes (str s) "UTF-8")]
-    (.update hasher str-bytes)
-    (hex-encode (.digest hasher))))
 
 
 ;; ## Paths

--- a/src/vault/util.clj
+++ b/src/vault/util.clj
@@ -132,16 +132,32 @@
   (.encodeToString
     (Base64/getEncoder)
     ^bytes
-    (if (string? data)
+    (cond
+      (bytes? data)
+      data
+
+      (string? data)
       (.getBytes ^String data "UTF-8")
-      data)))
+
+      :else
+      (throw (IllegalArgumentException.
+               (str "Don't know how to base64-encode value with type: "
+                    (class data) " (expected a string or byte array)"))))))
 
 
 (defn base64-decode
-  "Decode the given base-64 string into byte data."
-  ^bytes
-  [data]
-  (.decode (Base64/getDecoder) (str data)))
+  "Decode the given base-64 string into byte or string data."
+  ([data]
+   (base64-decode data false))
+  ([data as-string?]
+   (when-not (string? data)
+     (throw (IllegalArgumentException.
+              (str "Don't know how to base64-decode value with type: "
+                   (class data) " (expected a string)"))))
+   (let [bs (.decode (Base64/getDecoder) ^String data)]
+     (if as-string?
+       (String. bs "UTF-8")
+       bs))))
 
 
 (defn sha-256

--- a/test/vault/secret/transit_test.clj
+++ b/test/vault/secret/transit_test.clj
@@ -112,4 +112,4 @@
           (is (= 0 (:min-available-version key-info)))
           (is (= 2 (:min-encryption-version key-info)))
           (is (thrown-with-msg? Exception #"requested version for encryption is less than the minimum encryption key version"
-            (transit/encrypt-data! client "test" "gimme the old one" {:key-version 1}))))))))
+                (transit/encrypt-data! client "test" "gimme the old one" {:key-version 1}))))))))

--- a/test/vault/secret/transit_test.clj
+++ b/test/vault/secret/transit_test.clj
@@ -1,0 +1,115 @@
+(ns vault.secret.transit-test
+  (:require
+    [clojure.test :refer [deftest testing is]]
+    [vault.integration :refer [with-dev-server cli]]
+    [vault.secret.transit :as transit]))
+
+
+(deftest ^:integration http-api
+  (with-dev-server
+    (cli "secrets" "enable" "transit")
+    (testing "on missing keys"
+      (testing "read-key"
+        (is (thrown-with-msg? Exception #"not found"
+              (transit/read-key client "missing"))
+            "should throw not-found error"))
+      (testing "rotate-key!"
+        (is (thrown-with-msg? Exception #"not found"
+              (transit/rotate-key! client "missing"))
+            "should throw not-found error"))
+      (testing "update-key-configuration!"
+        (is (thrown-with-msg? Exception #"no existing key .+ found"
+              (transit/update-key-configuration!
+                client "missing"
+                {:min-encryption-version 2}))
+            "should throw not-found error"))
+      ;; NOTE: not covering encrypt-data, since it automatically creates a key
+      (testing "decrypt-data!"
+        (is (thrown-with-msg? Exception #"encryption key not found"
+              (transit/decrypt-data!
+                client "missing"
+                "vault:v1:SSBhbSBMcnJyLCBydWxlciBvZiB0aGUgcGxhbmV0IE9taWNyb24gUGVyc2VpIDgh"))
+            "should throw not-found error")))
+    (cli "write" "-force" "transit/keys/test")
+    (testing "read-key"
+      (let [key-info (transit/read-key client "test")]
+        (is (= "test" (:name key-info)))
+        (is (= "aes256-gcm96" (:type key-info)))
+        (is (true? (:supports-encryption key-info)))
+        (is (true? (:supports-decryption key-info)))
+        (is (false? (:supports-signing key-info)))
+        (is (= 0 (:min-available-version key-info)))
+        (is (= 0 (:min-encryption-version key-info)))
+        (is (= 1 (:min-decryption-version key-info)))
+        (is (= 1 (:latest-version key-info)))
+        (is (map? (:keys key-info)))
+        (is (= 1 (count (:keys key-info))))
+        (let [[version created-at] (first (:keys key-info))]
+          (is (= 1 version))
+          (is (inst? created-at)))))
+    (testing "single mode"
+      (let [plaintext "I am Lrrr, ruler of the planet Omicron Persei 8!"
+            ciphertext (atom nil)]
+        (testing "encrypt-data!"
+          (let [result (transit/encrypt-data! client "test" plaintext)]
+            (is (string? (:ciphertext result)))
+            (is (= 1 (:key-version result)))
+            (reset! ciphertext (:ciphertext result))))
+        (testing "decrypt-data!"
+          (testing "to bytes"
+            (let [result (transit/decrypt-data! client "test" @ciphertext)]
+              (is (bytes? (:plaintext result)))
+              (is (= plaintext (String. ^bytes (:plaintext result) "UTF-8")))))
+          (testing "to string"
+            (let [result (transit/decrypt-data! client "test" @ciphertext {:as-string true})]
+              (is (string? (:plaintext result)))
+              (is (= plaintext (:plaintext result))))))))
+    (testing "batch mode"
+      (let [inputs [{:plaintext "Good news, everyone!"
+                     :reference "Professor"}
+                    {:plaintext "Bite my shiny metal ass"
+                     :reference "Bender"}
+                    {:plaintext "Oh lord"
+                     :reference "Leela"}]
+            batch (atom nil)]
+        (testing "encrypt-data!"
+          (let [result (transit/encrypt-data! client "test" inputs)]
+            (is (vector? result))
+            (is (= 3 (count result)))
+            (is (= ["Professor" "Bender" "Leela"] (map :reference result)))
+            (is (every? :ciphertext result))
+            (is (every? #(= 1 (:key-version %)) result))
+            (reset! batch result)))
+        (testing "decrypt-data!"
+          (testing "to bytes"
+            (let [result (transit/decrypt-data! client "test" @batch)]
+              (is (vector? result))
+              (is (= 3 (count result)))
+              (is (= ["Professor" "Bender" "Leela"] (map :reference result)))
+              (is (every? (comp bytes? :plaintext) result))
+              (is (= "Good news, everyone!" (String. (:plaintext (first result)) "UTF-8")))))
+          (testing "to string"
+            (let [result (transit/decrypt-data! client "test" @batch {:as-string true})]
+              (is (vector? result))
+              (is (= inputs result)))))))
+    (testing "rotation"
+      (testing "rotate-key!"
+        (let [key-info (transit/rotate-key! client "test")]
+          (is (= "test" (:name key-info)))
+          (is (= "aes256-gcm96" (:type key-info)))
+          (is (= 0 (:min-available-version key-info)))
+          (is (= 0 (:min-encryption-version key-info)))
+          (is (= 1 (:min-decryption-version key-info)))
+          (is (= 2 (:latest-version key-info)))
+          (is (map? (:keys key-info)))
+          (is (= #{1 2} (set (keys (:keys key-info)))))
+          (is (inst? (get-in key-info [:keys 2])))))
+      (testing "update-key-configuration!"
+        (let [key-info (transit/update-key-configuration!
+                         client "test"
+                         {:min-encryption-version 2})]
+          (is (= "test" (:name key-info)))
+          (is (= 0 (:min-available-version key-info)))
+          (is (= 2 (:min-encryption-version key-info)))
+          (is (thrown-with-msg? Exception #"requested version for encryption is less than the minimum encryption key version"
+            (transit/encrypt-data! client "test" "gimme the old one" {:key-version 1}))))))))

--- a/test/vault/util_test.clj
+++ b/test/vault/util_test.clj
@@ -76,12 +76,7 @@
           data (.getBytes good-news)]
       (is (= "R29vZCBuZXdzLCBldmVyeW9uZSE=" (u/base64-encode data)))
       (is (= "R29vZCBuZXdzLCBldmVyeW9uZSE=" (u/base64-encode good-news)))
-      (is (= good-news (String. (u/base64-decode "R29vZCBuZXdzLCBldmVyeW9uZSE="))))))
-  (testing "sha-256"
-    (is (= "dbd318c1c462aee872f41109a4dfd3048871a03dedd0fe0e757ced57dad6f2d7"
-           (u/sha-256 "foo bar baz")))
-    (is (= "64989ccbf3efa9c84e2afe7cee9bc5828bf0fcb91e44f8c1e591638a2c2e90e3"
-           (u/sha-256 "alpha beta gamma")))))
+      (is (= good-news (String. (u/base64-decode "R29vZCBuZXdzLCBldmVyeW9uZSE=")))))))
 
 
 (deftest paths


### PR DESCRIPTION
This PR focuses on the [Transit secrets engine](https://developer.hashicorp.com/vault/api-docs/secret/transit) implementation. There are a few bug fixes (several methods did not properly coerce their responses) and two significant behavioral changes.

First, all inputs that need to be sent as a base64 string are automatically encoded by the client, rather than requiring the caller to do so. Similarly, when decrypting data the result is automatically decoded from base64 into a byte array, or the caller can now also opt into string-coercion.

Second, the encryption and decryption batch modes are directly invoked by providing a collection of data rather than a single item, which is much more natural than passing a `nil` for the data and then specifying a separate `:batch-input` option. The docstrings have been updated to clarify the two calling styles.

Finally, I added integration tests covering all of the implemented methods.