### PR TITLE
Pass observability information explicitly to control-flow handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ should be minor.
   if they support metadata, similar to normal responses.
 - `vault.client/config-client` accepts options for configuring the Vault
   client, as in `new-client`.
+- Control flow handler callbacks accept result observability information
+  directly, in addition to it being passed as value metadata or exception data.
 
 ### Removed
 - Removed the unused `vault.util/sha-256` function.

--- a/doc/control-flow.md
+++ b/doc/control-flow.md
@@ -96,16 +96,19 @@ This is an example of building a more advanced control-flow handler which:
 
 
   (on-success!
-    [_ state data]
+    [_ state info data]
+    (trace/with-data (:span state)
+      (ken/annotate info))
     (d/success! (:result state) data))
 
 
   (on-error!
-    [_ state ex]
+    [_ state info ex]
     (trace/with-data (:span state)
       (ken/observe
         (assoc info
                :ken.event/label :vault.client/error
+               :ken.event/level :warn
                :ken.event/error ex)))
     (if (and (retryable? ex)
              (< (+ (System/nanoTime) (* retry-interval 1000 1000))

--- a/src/vault/client/flow.cljc
+++ b/src/vault/client/flow.cljc
@@ -23,12 +23,12 @@
     may contain additional observability information.")
 
   (on-success!
-    [handler state data]
+    [handler state info data]
     "Callback indicating a successful response with the given response data.
     Should modify the state; the result of this call is not used.")
 
   (on-error!
-    [handler state ex]
+    [handler state info ex]
     "Callback indicating a failure response with the given exception. Should
     modify the state; the result of this call is not used.")
 
@@ -82,12 +82,12 @@
 
 
   (on-success!
-    [_ state data]
+    [_ state _ data]
     (deliver state data))
 
 
   (on-error!
-    [_ state ex]
+    [_ state _ ex]
     (deliver state ex))
 
 
@@ -126,12 +126,12 @@
 
 
   (on-success!
-    [_ state data]
+    [_ state _ data]
     (deliver state data))
 
 
   (on-error!
-    [_ state ex]
+    [_ state _ ex]
     (deliver state ex))
 
 
@@ -178,12 +178,12 @@
 
 
        (on-success!
-         [_ state data]
+         [_ state _ data]
          (.complete ^CompletableFuture state data))
 
 
        (on-error!
-         [_ state ex]
+         [_ state _ ex]
          (.completeExceptionally ^CompletableFuture state ex))
 
 

--- a/src/vault/client/mock.clj
+++ b/src/vault/client/mock.clj
@@ -113,7 +113,7 @@
       handler nil
       (fn success
         [state]
-        (f/on-success! handler state data)))))
+        (f/on-success! handler state nil data)))))
 
 
 (defn ^:no-doc error-response
@@ -124,7 +124,7 @@
       handler nil
       (fn error
         [state]
-        (f/on-error! handler state ex)))))
+        (f/on-error! handler state nil ex)))))
 
 
 (defn ^:no-doc list-paths

--- a/test/vault/client/flow_test.clj
+++ b/test/vault/client/flow_test.clj
@@ -18,7 +18,7 @@
                    (:flow client) nil
                    (fn request
                      [state]
-                     (f/on-success! handler state :ok))))]
+                     (f/on-success! handler state nil :ok))))]
     (is (= :ok (f/call-sync api-fn client 123 true)))))
 
 
@@ -31,7 +31,7 @@
                        [state]
                        (is (instance? IPending state))
                        (is (not (realized? state)))
-                       (is (any? (f/on-success! handler state :ok)))
+                       (is (any? (f/on-success! handler state nil :ok)))
                        (is (realized? state))))]
         (is (= :ok result))
         (is (= :ok (f/await handler result 1 :not-yet)))
@@ -44,7 +44,7 @@
                 [state]
                 (is (instance? IPending state))
                 (is (not (realized? state)))
-                (is (any? (f/on-error! handler state (RuntimeException. "BOOM"))))
+                (is (any? (f/on-error! handler state nil (RuntimeException. "BOOM"))))
                 (is (realized? state)))))))))
 
 
@@ -62,7 +62,7 @@
         (is (instance? IPending result))
         (is (not (realized? result)))
         (is (= :not-yet (f/await handler result 1 :not-yet)))
-        (is (any? (f/on-success! handler @state-ref :ok)))
+        (is (any? (f/on-success! handler @state-ref nil :ok)))
         (is (realized? result))
         (is (= :ok @result))
         (is (= :ok (f/await handler result 1 :not-yet)))
@@ -79,7 +79,7 @@
         (is (instance? IPending result))
         (is (not (realized? result)))
         (is (= :not-yet (f/await handler result 1 :not-yet)))
-        (is (any? (f/on-error! handler @state-ref (RuntimeException. "BOOM"))))
+        (is (any? (f/on-error! handler @state-ref nil (RuntimeException. "BOOM"))))
         (is (realized? result))
         (is (instance? RuntimeException @result))
         (is (= "BOOM" (ex-message @result)))
@@ -103,7 +103,7 @@
         (is (instance? CompletableFuture result))
         (is (not (.isDone result)))
         (is (= :not-yet (f/await handler result 1 :not-yet)))
-        (is (any? (f/on-success! handler @state-ref :ok)))
+        (is (any? (f/on-success! handler @state-ref nil :ok)))
         (is (.isDone result))
         (is (= :ok @result))
         (is (= :ok (f/await handler result 1 :not-yet)))
@@ -120,7 +120,7 @@
         (is (instance? CompletableFuture result))
         (is (not (.isDone result)))
         (is (= :not-yet (f/await handler result 1 :not-yet)))
-        (is (any? (f/on-error! handler @state-ref (RuntimeException. "BOOM"))))
+        (is (any? (f/on-error! handler @state-ref nil (RuntimeException. "BOOM"))))
         (is (.isDone result))
         (is (thrown-with-msg? Exception #"BOOM"
               @result))

--- a/test/vault/client/http_test.clj
+++ b/test/vault/client/http_test.clj
@@ -46,7 +46,7 @@
         (with-redefs [http-client/request (mock-request
                                             {:status 400
                                              :body "{\"errors\": []}"})]
-          (is (thrown-with-msg? Exception #"Vault HTTP error: bad request"
+          (is (thrown-with-msg? Exception #"Vault HTTP error on foo/bar \(400\) bad request"
                 (http/call-api client :get "foo/bar" {})))))
       (testing "and custom handling"
         (with-redefs [http-client/request (mock-request


### PR DESCRIPTION
Further developments from pursuing deeper integration in the Amperity app. The "response info" which pulls observability data such as the HTTP status code, headers, request id, and so on is attached to the returned values as metadata, or to exceptions in the `ex-data` map. The control flow handler is expected to pull it from these sources to record to the tracing system.

However, there's one spot where this falls through, because in the event of a non-success response, the `handle-failure` function is called on the exception _before_ it is passed to the control flow, and is allowed to replace it with a value. One use for this is implementing a `:not-found` option, such as in `kv2/read-secret`. An extremely common pattern for this is to tolerate missing secrets by passing `:not-found nil`, then checking for presence of the result. However, `nil` can't carry metadata! So in this case, the control flow handler would be missing all of the response information.

Instead, just have the client pass the response info directly to the `on-success!` and `on-error!` protocol methods, similar to `call`. It's still attached as metadata and exception data, but now the flow handler is not reliant on those channels.