### PR TITLE
Veil secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ This change log follows the conventions of [keepachangelog.com](http://keepachan
 
 ## [Unreleased]
 
-...
+### Changed
+- The client authentication state and lease store are now wrapped in an opaque
+  data type to prevent accidental exposure in logs and other printed output.
 
 
 ## [2.1.583] - 2023-09-25

--- a/src/vault/client.cljc
+++ b/src/vault/client.cljc
@@ -84,7 +84,7 @@
     (fn tick
       []
       (try
-        (auth/maintain! (:auth client) renew-auth-token!)
+        (auth/maintain! client renew-auth-token!)
         (lease/maintain! client renew-lease!)
         (catch InterruptedException _
           nil)

--- a/src/vault/client/http.clj
+++ b/src/vault/client/http.clj
@@ -282,8 +282,7 @@
   "Common logic for generating credentials which can be rotated in the future."
   [client api-label method path params opts]
   (if-let [data (and (not (:refresh? opts))
-                     (lease/find-data (:leases client)
-                                      (:cache-key params)))]
+                     (lease/find-data client (:cache-key params)))]
     ;; Re-use cached secret.
     (cached-response client api-label (:info params) data)
     ;; No cached value available, call API.
@@ -306,7 +305,7 @@
                          method path params
                          (assoc opts :refresh? true)))]
                (lease/put!
-                 (:leases client)
+                 client
                  (-> lease
                      (assoc ::lease/key (:cache-key params))
                      (lease/renewable-lease opts)

--- a/src/vault/client/http.clj
+++ b/src/vault/client/http.clj
@@ -21,7 +21,7 @@
   "Produce a map of options to pass to the HTTP client from the provided
   method, API path, and other request parameters."
   [client method path params]
-  (let [token (::auth/token @(:auth client))]
+  (let [token (::auth/token (auth/current (:auth client)))]
     (->
       (:http-opts client)
       (assoc :accept :json)
@@ -344,7 +344,7 @@
 
   (auth-info
     [_]
-    @auth)
+    (auth/current auth))
 
 
   (authenticate!
@@ -355,7 +355,7 @@
       (when-not (and (map? auth-info) (::auth/token auth-info))
         (throw (IllegalArgumentException.
                  "Client authentication must be a map of information containing an auth token.")))
-      (reset! auth auth-info)
+      (auth/set! auth auth-info)
       this)))
 
 

--- a/src/vault/client/mock.clj
+++ b/src/vault/client/mock.clj
@@ -24,7 +24,7 @@
 
   (auth-info
     [_]
-    @auth)
+    (auth/current auth))
 
 
   (authenticate!
@@ -35,7 +35,7 @@
       (when-not (and (map? auth-info) (::auth/client-token auth-info))
         (throw (IllegalArgumentException.
                  "Client authentication must be a map of information containing a client-token.")))
-      (reset! auth auth-info)
+      (auth/set! auth auth-info)
       this)))
 
 

--- a/src/vault/secret/kv/v1.clj
+++ b/src/vault/secret/kv/v1.clj
@@ -208,7 +208,7 @@
            info {::mount mount, ::path path}
            cache-key [::secret mount path]
            cached (when-not (:refresh? opts)
-                    (lease/find-data (:leases client) cache-key))]
+                    (lease/find-data client cache-key))]
        (if cached
          (http/cached-response client ::read-secret info cached)
          (http/call-api
@@ -224,8 +224,8 @@
                             (:ttl opts))
                     data (u/keywordize-keys (get body "data"))]
                 (when lease
-                  (lease/invalidate! (:leases client) cache-key)
-                  (lease/put! (:leases client) lease data))
+                  (lease/invalidate! client cache-key)
+                  (lease/put! client lease data))
                 (vary-meta data merge lease)))
             :handle-error
             (fn handle-error
@@ -245,7 +245,7 @@
     (let [mount (::mount client default-mount)
           path (u/trim-path path)
           cache-key [::secret mount path]]
-      (lease/invalidate! (:leases client) cache-key)
+      (lease/invalidate! client cache-key)
       (http/call-api
         client ::write-secret!
         :post (u/join-path mount path)
@@ -259,7 +259,7 @@
     (let [mount (::mount client default-mount)
           path (u/trim-path path)
           cache-key [::secret mount path]]
-      (lease/invalidate! (:leases client) cache-key)
+      (lease/invalidate! client cache-key)
       (http/call-api
         client ::delete-secret!
         :delete (u/join-path mount path)

--- a/src/vault/secret/kv/v2.clj
+++ b/src/vault/secret/kv/v2.clj
@@ -672,7 +672,7 @@
                   (assoc ::version version))
            cache-key [::secret mount path]
            cached (when-not (:refresh? opts)
-                    (lease/find-data (:leases client) cache-key))]
+                    (lease/find-data client cache-key))]
        (if (and cached
                 (or (nil? version)
                     (= version (::version (meta cached)))))
@@ -696,8 +696,8 @@
                              (u/keywordize-keys)
                              (vary-meta merge metadata))]
                 (when lease
-                  (lease/invalidate! (:leases client) cache-key)
-                  (lease/put! (:leases client) lease data))
+                  (lease/invalidate! client cache-key)
+                  (lease/put! client lease data))
                 (vary-meta data merge lease)))
             :handle-error
             (fn handle-error
@@ -718,7 +718,7 @@
      (let [mount (::mount client default-mount)
            path (u/trim-path path)
            cache-key [::secret mount path]]
-       (lease/invalidate! (:leases client) cache-key)
+       (lease/invalidate! client cache-key)
        (http/call-api
          client ::write-secret!
          :post (u/join-path mount "data" path)
@@ -736,7 +736,7 @@
      (let [mount (::mount client default-mount)
            path (u/trim-path path)
            cache-key [::secret mount path]]
-       (lease/invalidate! (:leases client) cache-key)
+       (lease/invalidate! client cache-key)
        (http/call-api
          client ::patch-secret!
          :patch (u/join-path mount "data" path)
@@ -754,7 +754,7 @@
     (let [mount (::mount client default-mount)
           path (u/trim-path path)
           cache-key [::secret mount path]]
-      (lease/invalidate! (:leases client) cache-key)
+      (lease/invalidate! client cache-key)
       (http/call-api
         client ::delete-secret!
         :delete (u/join-path mount "data" path)
@@ -766,7 +766,7 @@
     (let [mount (::mount client default-mount)
           path (u/trim-path path)
           cache-key [::secret mount path]]
-      (lease/invalidate! (:leases client) cache-key)
+      (lease/invalidate! client cache-key)
       (http/call-api
         client ::destroy-secret!
         :delete (u/join-path mount "metadata" path)
@@ -778,7 +778,7 @@
     (let [mount (::mount client default-mount)
           path (u/trim-path path)
           cache-key [::secret mount path]]
-      (lease/invalidate! (:leases client) cache-key)
+      (lease/invalidate! client cache-key)
       (http/call-api
         client ::delete-versions!
         :post (u/join-path mount "delete" path)
@@ -792,7 +792,7 @@
     (let [mount (::mount client default-mount)
           path (u/trim-path path)
           cache-key [::secret mount path]]
-      (lease/invalidate! (:leases client) cache-key)
+      (lease/invalidate! client cache-key)
       (http/call-api
         client ::undelete-versions!
         :post (u/join-path mount "undelete" path)
@@ -806,7 +806,7 @@
     (let [mount (::mount client default-mount)
           path (u/trim-path path)
           cache-key [::secret mount path]]
-      (lease/invalidate! (:leases client) cache-key)
+      (lease/invalidate! client cache-key)
       (http/call-api
         client ::destroy-versions!
         :post (u/join-path mount "destroy" path)

--- a/src/vault/sys/leases.clj
+++ b/src/vault/sys/leases.clj
@@ -74,12 +74,12 @@
         :handle-response http/lease-info
         :on-success (fn update-lease
                       [lease]
-                      (lease/update! (:leases client) lease))})))
+                      (lease/update! client lease))})))
 
 
   (revoke-lease!
     [client lease-id]
-    (lease/delete! (:leases client) lease-id)
+    (lease/delete! client lease-id)
     (http/call-api
       client ::revoke-lease!
       :put "sys/leases/revoke"

--- a/src/vault/util.cljc
+++ b/src/vault/util.cljc
@@ -194,3 +194,26 @@
   [inst & body]
   `(with-redefs [now (constantly ~inst)]
      ~@body))
+
+
+;; ## Secret Protection
+
+#?(:bb nil
+   :clj (deftype Veil [value]))
+
+
+(defn veil
+  "Wrap the provided value in an opaque type which will not reveal its contents
+  when printed. No effect in babashka."
+  [x]
+  #?(:bb x
+     :clj (->Veil x)))
+
+
+(defn unveil
+  "Unwrap the hidden value if `x` is veiled. Otherwise, returns `x` directly."
+  [x]
+  #?(:bb x
+     :clj (if (instance? Veil x)
+            (.-value ^Veil x)
+            x)))

--- a/src/vault/util.cljc
+++ b/src/vault/util.cljc
@@ -199,7 +199,8 @@
 ;; ## Secret Protection
 
 #?(:bb nil
-   :clj (deftype Veil [value]))
+   :clj (deftype Veil
+          [value]))
 
 
 (defn veil

--- a/test/vault/lease_test.clj
+++ b/test/vault/lease_test.clj
@@ -42,55 +42,61 @@
 
 (deftest get-lease
   (let [store (lease/new-store)
+        store* (u/unveil store)
+        client {:leases store}
         lease-id "foo/bar/123"
         lease {::lease/id lease-id
                ::lease/expires-at (Instant/parse "2022-09-21T18:00:00Z")
                ::lease/data {:foo 123}}]
-    (swap! store assoc lease-id lease)
+    (swap! store* assoc lease-id lease)
     (testing "for current lease"
       (u/with-now (Instant/parse "2022-09-21T17:00:00Z")
-        (is (= lease (lease/get-lease store lease-id))
+        (is (= lease (lease/get-lease client lease-id))
             "should return lease")))
     (testing "for expired lease"
       (u/with-now (Instant/parse "2022-09-21T19:00:00Z")
-        (is (nil? (lease/get-lease store lease-id))
+        (is (nil? (lease/get-lease client lease-id))
             "should return nil")))
     (testing "for missing lease"
-      (is (nil? (lease/get-lease store "foo/bar/456"))
+      (is (nil? (lease/get-lease client "foo/bar/456"))
           "should return nil"))))
 
 
 (deftest find-lease-data
   (let [store (lease/new-store)
+        store* (u/unveil store)
+        client {:leases store}
         lease-id "foo/bar/123"
         cache-key [:foo 123]
         lease {::lease/id lease-id
                ::lease/key cache-key
                ::lease/expires-at (Instant/parse "2022-09-21T18:00:00Z")
                ::lease/data {:foo 123}}]
-    (swap! store assoc lease-id lease)
+    (swap! store* assoc lease-id lease)
     (testing "for current lease"
       (u/with-now (Instant/parse "2022-09-21T17:00:00Z")
-        (let [result (lease/find-data store cache-key)]
+        (let [result (lease/find-data client cache-key)]
           (is (= {:foo 123} result)
               "should return lease data")
           (is (= (dissoc lease ::lease/data) (meta result))
               "should attach lease metadata"))))
     (testing "for expired lease"
       (u/with-now (Instant/parse "2022-09-21T19:00:00Z")
-        (is (nil? (lease/find-data store cache-key))
+        (is (nil? (lease/find-data client cache-key))
             "should return nil")))
     (testing "for missing lease"
-      (is (nil? (lease/find-data store [:foo 456]))
+      (is (nil? (lease/find-data client [:foo 456]))
           "should return nil"))))
 
 
 (deftest put-lease
   (testing "current lease"
-    (let [store (lease/new-store)]
+    (let [store (lease/new-store)
+          store* (u/unveil store)
+          client {:leases store}]
       (u/with-now (Instant/parse "2022-09-21T17:00:00Z")
         (is (= {:foo 123}
-               (lease/put! store
+               (lease/put! client
                            {::lease/id "foo/bar/123"
                             ::lease/expires-at (Instant/parse "2022-09-21T18:00:00Z")}
                            {:foo 123}))
@@ -99,54 +105,64 @@
                 {::lease/id "foo/bar/123"
                  ::lease/expires-at (Instant/parse "2022-09-21T18:00:00Z")
                  ::lease/data {:foo 123}}}
-               @store)
+               @store*)
             "lease should be stored"))))
   (testing "expired lease"
-    (let [store (lease/new-store)]
+    (let [store (lease/new-store)
+          store* (u/unveil store)
+          client {:leases store}]
       (u/with-now (Instant/parse "2022-09-21T17:00:00Z")
         (is (= {:foo 456}
-               (lease/put! store
+               (lease/put! client
                            {::lease/id "foo/bar/456"
                             ::lease/expires-at (Instant/parse "2022-09-21T16:00:00Z")}
                            {:foo 456}))
             "put should return data map")
-        (is (empty? @store)
+        (is (empty? @store*)
             "lease should not be stored")))))
 
 
 (deftest update-lease
   (testing "missing lease"
-    (let [store (lease/new-store)]
-      (is (nil? (lease/update! store {::lease/id "foo/bar/123"})))
-      (is (empty? @store))))
+    (let [store (lease/new-store)
+          store* (u/unveil store)
+          client {:leases store}]
+      (is (nil? (lease/update! client {::lease/id "foo/bar/123"})))
+      (is (empty? @store*))))
   (testing "present lease"
     (let [store (lease/new-store)
+          store* (u/unveil store)
+          client {:leases store}
           lease-id "foo/bar/123"
           lease {::lease/id lease-id
                  ::lease/expires-at (Instant/parse "2022-09-21T18:00:00Z")
                  ::lease/data {:foo 123}}
           t2 (Instant/parse "2022-09-21T22:00:00Z")
           lease' (assoc lease ::lease/expires-at t2)]
-      (swap! store assoc lease-id lease)
-      (is (= lease' (lease/update! store {::lease/id lease-id, ::lease/expires-at t2})))
-      (is (= lease' (first (vals @store)))))))
+      (swap! store* assoc lease-id lease)
+      (is (= lease' (lease/update! client {::lease/id lease-id, ::lease/expires-at t2})))
+      (is (= lease' (first (vals @store*)))))))
 
 
 (deftest delete-lease
   (let [store (lease/new-store)
+        store* (u/unveil store)
+        client {:leases store}
         lease-id "foo/bar/123"
         lease {::lease/id lease-id
                ::lease/expires-at (Instant/parse "2022-09-21T18:00:00Z")
                ::lease/data {:foo 123}}]
-    (swap! store assoc lease-id lease)
-    (is (nil? (lease/delete! store "foo/baz/000")))
-    (is (= 1 (count @store)))
-    (is (nil? (lease/delete! store lease-id)))
-    (is (empty? @store))))
+    (swap! store* assoc lease-id lease)
+    (is (nil? (lease/delete! client "foo/baz/000")))
+    (is (= 1 (count @store*)))
+    (is (nil? (lease/delete! client lease-id)))
+    (is (empty? @store*))))
 
 
 (deftest invalidate-lease
   (let [store (lease/new-store)
+        store* (u/unveil store)
+        client {:leases store}
         lease-a-id "foo/bar/123"
         lease-a {::lease/id lease-a-id
                  ::lease/key [:foo 123]
@@ -157,12 +173,12 @@
                  ::lease/key [:foo 456]
                  ::lease/expires-at (Instant/parse "2022-09-21T18:00:00Z")
                  ::lease/data {:foo 456}}]
-    (swap! store assoc lease-a-id lease-a)
-    (swap! store assoc lease-b-id lease-b)
-    (is (nil? (lease/invalidate! store [:xyz true])))
-    (is (= #{lease-a-id lease-b-id} (set (keys @store))))
-    (is (nil? (lease/invalidate! store [:foo 456])))
-    (is (= [lease-a-id] (keys @store)))))
+    (swap! store* assoc lease-a-id lease-a)
+    (swap! store* assoc lease-b-id lease-b)
+    (is (nil? (lease/invalidate! client [:xyz true])))
+    (is (= #{lease-a-id lease-b-id} (set (keys @store*))))
+    (is (nil? (lease/invalidate! client [:foo 456])))
+    (is (= [lease-a-id] (keys @store*)))))
 
 
 (deftest maintenance-helpers
@@ -252,6 +268,8 @@
 (deftest maintenance-logic
   (testing "on active lease"
     (let [store (lease/new-store)
+          store* (u/unveil store)
+          client {:leases store}
           lease-id "foo/bar/123"
           lease {::lease/id lease-id
                  ::lease/renewable? true
@@ -262,15 +280,17 @@
                  ::lease/data {:foo 123}}
           renew-calls (atom 0)
           renew-fn (fn [_] (swap! renew-calls inc))]
-      (swap! store assoc lease-id lease)
+      (swap! store* assoc lease-id lease)
       (u/with-now (Instant/parse "2022-09-22T03:00:00Z")
-        (is (nil? (lease/maintain! {:leases store} renew-fn))))
+        (is (nil? (lease/maintain! client renew-fn))))
       (is (zero? @renew-calls)
           "should not call renew-fn")
-      (is (= lease (first (vals @store)))
+      (is (= lease (first (vals @store*)))
           "should leave lease unchanged in store")))
   (testing "on unrenewable lease"
     (let [store (lease/new-store)
+          store* (u/unveil store)
+          client {:leases store}
           lease-id "foo/bar/123"
           lease {::lease/id lease-id
                  ::lease/renewable? false
@@ -278,15 +298,17 @@
                  ::lease/data {:foo 123}}
           renew-calls (atom 0)
           renew-fn (fn [_] (swap! renew-calls inc))]
-      (swap! store assoc lease-id lease)
+      (swap! store* assoc lease-id lease)
       (u/with-now (Instant/parse "2022-09-22T08:59:50Z")
-        (is (nil? (lease/maintain! {:leases store} renew-fn))))
+        (is (nil? (lease/maintain! client renew-fn))))
       (is (zero? @renew-calls)
           "should not call renew-fn")
-      (is (= lease (first (vals @store)))
+      (is (= lease (first (vals @store*)))
           "should leave lease unchanged in store")))
   (testing "on lease in renewal backoff"
     (let [store (lease/new-store)
+          store* (u/unveil store)
+          client {:leases store}
           lease-id "foo/bar/123"
           lease {::lease/id lease-id
                  ::lease/renewable? true
@@ -296,16 +318,18 @@
                  ::lease/data {:foo 123}}
           renew-calls (atom 0)
           renew-fn (fn [_] (swap! renew-calls inc))]
-      (swap! store assoc lease-id lease)
+      (swap! store* assoc lease-id lease)
       (u/with-now (Instant/parse "2022-09-22T09:27:00Z")
-        (is (nil? (lease/maintain! {:leases store} renew-fn))))
+        (is (nil? (lease/maintain! client renew-fn))))
       (is (zero? @renew-calls)
           "should not call renew-fn")
-      (is (= lease (first (vals @store)))
+      (is (= lease (first (vals @store*)))
           "should leave lease unchanged in store")))
   (testing "on renewable lease"
     (testing "with successful renewal"
       (let [store (lease/new-store)
+            store* (u/unveil store)
+            client {:leases store}
             callbacks (atom #{})
             make-cb (fn [tag] (fn [_] (swap! callbacks conj tag)))
             lease-id "foo/bar/123"
@@ -319,13 +343,13 @@
                    ::lease/data {:foo 123}}
             renew-fn (fn [_]
                        (lease/update!
-                         store
+                         client
                          {::lease/id lease-id
                           ::lease/expires-at (Instant/parse "2022-09-22T10:30:00Z")}))]
-        (swap! store assoc lease-id lease)
+        (swap! store* assoc lease-id lease)
         (u/with-now (Instant/parse "2022-09-22T09:29:10Z")
-          (is (nil? (lease/maintain! {:leases store} renew-fn))))
-        (let [lease' (first (vals @store))]
+          (is (nil? (lease/maintain! client renew-fn))))
+        (let [lease' (first (vals @store*))]
           (is (= (Instant/parse "2022-09-22T10:30:00Z")
                  (::lease/expires-at lease'))
               "should update lease expiry")
@@ -336,6 +360,8 @@
             "should invoke on-renew callbacks")))
     (testing "with failed renewal"
       (let [store (lease/new-store)
+            store* (u/unveil store)
+            client {:leases store}
             callbacks (atom #{})
             make-cb (fn [tag] (fn [_] (swap! callbacks conj tag)))
             lease-id "foo/bar/123"
@@ -348,16 +374,18 @@
                    ::lease/on-error (make-cb :err)
                    ::lease/data {:foo 123}}
             renew-fn (fn [_] (throw (RuntimeException. "BOOM")))]
-        (swap! store assoc lease-id lease)
+        (swap! store* assoc lease-id lease)
         (u/with-now (Instant/parse "2022-09-22T09:29:10Z")
-          (is (nil? (lease/maintain! {:leases store} renew-fn))))
-        (is (= lease (first (vals @store)))
+          (is (nil? (lease/maintain! client renew-fn))))
+        (is (= lease (first (vals @store*)))
             "should leave lease unchanged in store")
         (is (= #{:err} @callbacks)
             "should invoke on-error callbacks"))))
   (testing "on rotatable lease"
     (testing "with successful rotation"
       (let [store (lease/new-store)
+            store* (u/unveil store)
+            client {:leases store}
             callbacks (atom #{})
             make-cb (fn [tag] (fn [_] (swap! callbacks conj tag)))
             lease-id "foo/bar/123"
@@ -371,17 +399,19 @@
                    ::lease/data {:foo 123}}
             renew-calls (atom 0)
             renew-fn (fn [_] (swap! renew-calls inc))]
-        (swap! store assoc lease-id lease)
+        (swap! store* assoc lease-id lease)
         (u/with-now (Instant/parse "2022-09-22T09:29:10Z")
-          (is (nil? (lease/maintain! {:leases store} renew-fn))))
+          (is (nil? (lease/maintain! client renew-fn))))
         (is (zero? @renew-calls)
             "should not call renew-fn")
-        (is (empty? @store)
+        (is (empty? @store*)
             "should remove old lease from store")
         (is (= #{:rotate} @callbacks)
             "should invoke on-rotate callbacks")))
     (testing "with failed rotation"
       (let [store (lease/new-store)
+            store* (u/unveil store)
+            client {:leases store}
             callbacks (atom #{})
             make-cb (fn [tag] (fn [_] (swap! callbacks conj tag)))
             lease-id "foo/bar/123"
@@ -395,17 +425,19 @@
                    ::lease/data {:foo 123}}
             renew-calls (atom 0)
             renew-fn (fn [_] (swap! renew-calls inc))]
-        (swap! store assoc lease-id lease)
+        (swap! store* assoc lease-id lease)
         (u/with-now (Instant/parse "2022-09-22T09:29:10Z")
-          (is (nil? (lease/maintain! {:leases store} renew-fn))))
+          (is (nil? (lease/maintain! client renew-fn))))
         (is (zero? @renew-calls)
             "should not call renew-fn")
-        (is (= lease (first (vals @store)))
+        (is (= lease (first (vals @store*)))
             "should leave lease unchanged in store")
         (is (= #{:err} @callbacks)
             "should invoke on-error callbacks"))))
   (testing "on expired lease"
     (let [store (lease/new-store)
+          store* (u/unveil store)
+          client {:leases store}
           lease-id "foo/bar/123"
           lease {::lease/id lease-id
                  ::lease/renewable? true
@@ -414,15 +446,17 @@
                  ::lease/data {:foo 123}}
           renew-calls (atom 0)
           renew-fn (fn [_] (swap! renew-calls inc))]
-      (swap! store assoc lease-id lease)
+      (swap! store* assoc lease-id lease)
       (u/with-now (Instant/parse "2022-09-22T12:00:00Z")
-        (is (nil? (lease/maintain! {:leases store} renew-fn))))
+        (is (nil? (lease/maintain! client renew-fn))))
       (is (zero? @renew-calls)
           "should not call renew-fn")
-      (is (empty? @store)
+      (is (empty? @store*)
           "should remove it from store")))
   (testing "with unexpected error"
     (let [store (lease/new-store)
+          store* (u/unveil store)
+          client {:leases store}
           lease-id "foo/bar/123"
           lease {::lease/id lease-id
                  ::lease/renewable? true
@@ -431,10 +465,10 @@
                  ::lease/data {:foo 123}}
           renew-calls (atom 0)
           renew-fn (fn [_] (swap! renew-calls inc))]
-      (swap! store assoc lease-id lease)
+      (swap! store* assoc lease-id lease)
       (with-redefs [lease/renew? (fn [_] (throw (RuntimeException. "BOOM")))]
-        (is (nil? (lease/maintain! {:leases store} renew-fn))))
+        (is (nil? (lease/maintain! client renew-fn))))
       (is (zero? @renew-calls)
           "should not call renew-fn")
-      (is (= lease (first (vals @store)))
+      (is (= lease (first (vals @store*)))
           "should leave lease in store"))))


### PR DESCRIPTION
Despite the HTTP client defining a custom `Object#toString()` and `print-method`, there are cases where the internal state can still be exposed in logs and other print output. This specifically happens when the client is fed into a pretty-printer (such as [clj-commons/pretty](https://github.com/clj-commons/pretty)) which wind up traversing the client's attributes as a record type. This is undesirable, because the `auth` and `leases` fields contain secret information which should remain private.

To address this, we can define a new `Veil` type which hides the data in an internal field. There's a bunch of refactoring to go with this, mostly adjusting callsites to unveil the data before using it. To simplify this, and provide a more consistent interface, several functions in the `vault.auth` and `vault.lease` namespaces have shifted to accept clients directly instead of operating on the "store" atom.

Before this change:
```clojure
vault.repl=> (puget.printer/pprint client)
#vault.client.http.HTTPClient
{:address "http://127.0.0.1:8200",
 :auth #<Atom@3985175e {:vault.auth/token "t0p-53cr3t"}>,
 :flow #<vault.client.flow.SyncHandler@d91e8c7>,
 :http-opts nil,
 :leases #<Atom@66011fbc {}>,
 :maintenance-executor #<java.util.concurrent.ScheduledThreadPoolExecutor@77afdbc5 ...>,
 :maintenance-task #<Future@757ad227 pending>}
```

After:
```clojure
vault.repl=> (puget.printer/pprint client)
#vault.client.http.HTTPClient
{:address "http://127.0.0.1:8200",
 :auth #<vault.util.Veil@6137dc84>,
 :flow #<vault.client.flow.SyncHandler@22f1a340>,
 :http-opts nil,
 :leases #<vault.util.Veil@32f243f>,
 :maintenance-executor #<java.util.concurrent.ScheduledThreadPoolExecutor@7aa5292d ...>,
 :maintenance-task #<Future@25291901 pending>}
```