### PR TITLE
Include the `:vault.client/address` in flow handler info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ This change log follows the conventions of [keepachangelog.com](http://keepachan
 
 ## [Unreleased]
 
-...
+### Added
+- The `info` map passed into control flow handler methods now includes
+  the client's Vault address as `:vault.client/address`.
 
 
 ## [2.2.586] - 2023-10-13

--- a/build.clj
+++ b/build.clj
@@ -12,7 +12,7 @@
 (def basis (b/create-basis {:project "deps.edn"}))
 
 (def lib-name 'com.amperity/vault-clj)
-(def major-version "2.2")
+(def major-version "2.3")
 
 (def src-dirs ["src"])
 (def target-dir "target")

--- a/src/vault/client/http.clj
+++ b/src/vault/client/http.clj
@@ -126,7 +126,8 @@
         info (merge (:info params)
                     {:vault.client/api api-label
                      :vault.client/method method
-                     :vault.client/path path}
+                     :vault.client/path path
+                     :vault.client/address (:address client)}
                     (when-let [query (not-empty (:query-params params))]
                       {:vault.client/query query}))]
     (letfn [(make-request


### PR DESCRIPTION
If you have multiple Vault clusters, for example dev and prod, the Vault address can be useful for debugging and monitoring/observability.

I've tried to update the changelog, and bumped to the next minor version because though very minor, this is technically adding functionality.