### PR TITLE
Implement Azure auth method

### DIFF
--- a/src/vault/auth/azure.clj
+++ b/src/vault/auth/azure.clj
@@ -1,0 +1,68 @@
+(ns vault.auth.azure
+  (:require
+    [clojure.data.json :as json]
+    [vault.client.http :as http]
+    [vault.client.proto :as proto]
+    [vault.util :as u])
+  (:import
+    vault.client.http.HTTPClient))
+
+
+(def default-mount
+  "Default mount point for the auth method."
+  "azure")
+
+
+(defprotocol API
+  "Vault Azure auth method"
+
+  (login
+    [client params]
+    "Logs in to Vault using Azure credentials,
+    as per <https://developer.hashicorp.com/vault/docs/auth/azure>.
+
+    The `params` map is transformed into snake keys and used as the
+    request body to the login endpoint. See <https://developer.hashicorp.com/vault/api-docs/auth/azure#login>
+    for all supported parameters.
+
+    Common parameters are:
+    - `:role` - Vault role name
+    - `:jwt` - Azure access token
+    - `:subscription-id` - Azure subscription ID
+    - `:resource-group-name` - Azure resource group name
+    - `:vm-name` - When using an Azure VM system-assigned identity or managed identity, the name of the Azure VM")
+
+  (with-mount
+    [client mount]
+    "Configures the mount point of the auth method, if it is not the default.
+
+    Returns a new client. If `mount` is nil, returns a client with the default
+    mount point."))
+
+
+(extend-type HTTPClient
+
+  API
+
+  (login
+    [client {:keys [role jwt] :as params}]
+    (let [mount (::mount client default-mount)
+          api-path (u/join-path "auth" mount "login")
+          _ (prn params)
+          body (u/snakify-keys params)]
+      (http/call-api
+        client ::login
+        :post api-path
+        {:info {::mount mount}
+         :content-type :json
+         :body body
+         :handle-response u/kebabify-body-auth
+         :on-success (fn update-auth
+                       [auth]
+                       (proto/authenticate! client auth))})))
+
+  (with-mount
+    [client mount]
+    (if (some? mount)
+      (assoc client ::mount mount)
+      (dissoc client ::mount))))

--- a/src/vault/auth/azure.clj
+++ b/src/vault/auth/azure.clj
@@ -29,7 +29,7 @@
     - `:jwt` - Azure access token
     - `:subscription-id` - Azure subscription ID
     - `:resource-group-name` - Azure resource group name
-    - `:vm-name` - When using an Azure VM system-assigned identity or managed identity, the name of the Azure VM")
+    - `:vm-name` - When using an Azure VM's system-assigned or user-assigned identity, the name of the Azure VM")
 
   (with-mount
     [client mount]

--- a/src/vault/auth/azure.clj
+++ b/src/vault/auth/azure.clj
@@ -1,6 +1,5 @@
 (ns vault.auth.azure
   (:require
-    [clojure.data.json :as json]
     [vault.client.http :as http]
     [vault.client.proto :as proto]
     [vault.util :as u])
@@ -45,10 +44,9 @@
   API
 
   (login
-    [client {:keys [role jwt] :as params}]
+    [client params]
     (let [mount (::mount client default-mount)
           api-path (u/join-path "auth" mount "login")
-          _ (prn params)
           body (u/snakify-keys params)]
       (http/call-api
         client ::login


### PR DESCRIPTION
Resolves #108

The motivation to do this now is that we have a use case for code running on a standalone set of Azure VMs to use secrets in Vault.

Tested in a REPL with `bin/repl`. Anonymized / redacted output:

```clojure
vault.repl=> (azure/login client {:role "example" :jwt (System/getenv "AZURE_TOKEN") :resource-group-name "example" :subscription-id "example" :vm-name "example"})
{:accessor "...",
 :client-token "...",
 :entity-id "...",
 :lease-duration 60,
 :metadata {:app-id "example",
            :resource-group-name "example",
            :role "example",
            :subscription-id "example",
            :vm-name "example"},
 :mfa-requirement nil,
 :num-uses 0,
 :orphan true,
 :policies ["default" "example"],
 :renewable true,
 :token-policies ["default" "example"],
 :token-type "service"}
```