### PR TITLE
fix: merge per-request headers with client headers

### DIFF
--- a/src/vault/client/http.clj
+++ b/src/vault/client/http.clj
@@ -27,9 +27,9 @@
       opts
       (assoc :accept :json)
       (merge params)
-      (assoc :headers (merge (:headers opts) (:headers params)))
       (assoc :method method
-             :url (str (:address client) "/v1/" path))
+             :url (str (:address client) "/v1/" path)
+             :headers (merge (:headers opts) (:headers params))))
       (cond->
         token
         (assoc-in [:headers "X-Vault-Token"] token)

--- a/src/vault/client/http.clj
+++ b/src/vault/client/http.clj
@@ -29,7 +29,7 @@
       (merge params)
       (assoc :method method
              :url (str (:address client) "/v1/" path)
-             :headers (merge (:headers opts) (:headers params))))
+             :headers (merge (:headers opts) (:headers params)))
       (cond->
         token
         (assoc-in [:headers "X-Vault-Token"] token)

--- a/src/vault/client/http.clj
+++ b/src/vault/client/http.clj
@@ -21,11 +21,13 @@
   "Produce a map of options to pass to the HTTP client from the provided
   method, API path, and other request parameters."
   [client method path params]
-  (let [token (::auth/token (auth/current (:auth client)))]
+  (let [token (::auth/token (auth/current (:auth client)))
+        opts (:http-opts client)]
     (->
-      (:http-opts client)
+      opts
       (assoc :accept :json)
       (merge params)
+      (assoc :headers (merge (:headers opts) (:headers params)))
       (assoc :method method
              :url (str (:address client) "/v1/" path))
       (cond->

--- a/test/vault/client/http_test.clj
+++ b/test/vault/client/http_test.clj
@@ -111,7 +111,23 @@
           (is (= {:result true}
                  (http/call-api
                    client :foo :get "foo/bar"
-                   {:handle-response (constantly {:result true})}))))))))
+                   {:handle-response (constantly {:result true})}))))))
+    (testing "with per-request headers"
+      (let [client (assoc client :http-opts {:headers {"X-Vault-Namespace" "admin"}})
+            captured (atom nil)]
+        (with-redefs [http-client/request (fn [req callback]
+                                            (reset! captured req)
+                                            (callback {:opts req :status 204 :headers {} :body ""}))]
+          (http/call-api
+            client :foo :patch "foo/bar"
+            {:headers {"content-type" "application/merge-patch+json"}
+             :body "{}"}))
+        (testing "preserves the client's configured headers"
+          (is (= "admin" (get-in @captured [:headers "X-Vault-Namespace"]))))
+        (testing "keeps the per-request headers"
+          (is (= "application/merge-patch+json" (get-in @captured [:headers "content-type"]))))
+        (testing "keeps the auth token header"
+          (is (= "t0p-53cr5t" (get-in @captured [:headers "X-Vault-Token"]))))))))
 
 
 (deftest authentication

--- a/test/vault/client/http_test.clj
+++ b/test/vault/client/http_test.clj
@@ -122,12 +122,12 @@
             client :foo :patch "foo/bar"
             {:headers {"content-type" "application/merge-patch+json"}
              :body "{}"}))
-        (testing "preserves the client's configured headers"
-          (is (= "admin" (get-in @captured [:headers "X-Vault-Namespace"]))))
-        (testing "keeps the per-request headers"
-          (is (= "application/merge-patch+json" (get-in @captured [:headers "content-type"]))))
-        (testing "keeps the auth token header"
-          (is (= "t0p-53cr5t" (get-in @captured [:headers "X-Vault-Token"]))))))))
+        (is (= "admin" (get-in @captured [:headers "X-Vault-Namespace"]))
+            "preserves the client's configured headers")
+        (is (= "application/merge-patch+json" (get-in @captured [:headers "content-type"]))
+            "keeps the per-request headers")
+        (is (= "t0p-53cr5t" (get-in @captured [:headers "X-Vault-Token"]))
+            "keeps the auth token header")))))
 
 
 (deftest authentication


### PR DESCRIPTION
# Context
I was trying to patch a KV v2 secret with `kv/patch-secret!`. My Vault is on a non-root namespace, and the namespace is passed as the `X-Vault-Namespace` header, which I configured once on the client via `:http-opts`:

```clojure
(vault/config-client
  :http-opts {:headers {"X-Vault-Namespace" "my-custom-namespace"}})
```

Reads, writes, and lists all worked fine against that client. But every `patch` came back with `403 permission denied`, even though the token had the `patch` capability on the path.

## What I noticed
Digging in, I saw that `kv/patch-secret!` sets its own `:headers` (it needs `content-type: application/merge-patch+json`). Everything else uses `:content-type :json` with no `:headers` key.

Basically my per-request `:headers` were *replacing* the client's `:http-opts` headers instead of being combined with them. So the `X-Vault-Namespace` header I configured on the client never made it onto the PATCH
request.

## Root cause
In `vault.client.http/prepare-request`, the request was built by shallow-merging the
call params over `:http-opts`:

```clojure
(-> (:http-opts client)        ; {:headers {"X-Vault-Namespace" "my-custom-namespace"}}
    (assoc :accept :json)
    (merge params)             ; params :headers REPLACES :http-opts :headers
    ...)
```

And to fix, we should re-merge the original `:http-opts` headers under the per-call headers, so both
survive with the per-call headers winning on conflicts:

```clojure
(-> opts
    (assoc :accept :json)
    (merge params)
    (assoc :headers (merge (:headers opts) (:headers params)))
    ...)
```

And that's it!