### PR TITLE
Update CI configuration, fix lint issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,9 @@ commands:
             unzip vault_${VAULT_VERSION}_linux_amd64.zip
             sudo mv vault /usr/local/bin/vault
 
+orbs:
+  codecov: codecov/codecov@6.0.0
+
 
 # Job definitions
 jobs:
@@ -32,10 +35,10 @@ jobs:
       - run:
           name: Install cljstyle
           environment:
-            CLJSTYLE_VERSION: 0.15.0
+            CLJSTYLE_VERSION: 0.17.642
           command: |
-            wget https://github.com/greglook/cljstyle/releases/download/${CLJSTYLE_VERSION}/cljstyle_${CLJSTYLE_VERSION}_linux.zip
-            unzip cljstyle_${CLJSTYLE_VERSION}_linux.zip
+            wget https://github.com/greglook/cljstyle/releases/download/${CLJSTYLE_VERSION}/cljstyle_${CLJSTYLE_VERSION}_linux_amd64.zip
+            unzip cljstyle_${CLJSTYLE_VERSION}_linux_amd64.zip
       - run:
           name: Check source formatting
           command: "./cljstyle check --report"
@@ -47,7 +50,7 @@ jobs:
       - run:
           name: Install clj-kondo
           environment:
-            CLJ_KONDO_VERSION: 2022.11.02
+            CLJ_KONDO_VERSION: 2026.05.25
           command: |
             wget https://github.com/clj-kondo/clj-kondo/releases/download/v${CLJ_KONDO_VERSION}/clj-kondo-${CLJ_KONDO_VERSION}-linux-amd64.zip
             unzip clj-kondo-${CLJ_KONDO_VERSION}-linux-amd64.zip
@@ -101,20 +104,9 @@ jobs:
       - store_artifacts:
           path: target/coverage
           destination: coverage
-      - run:
-          name: Install codecov
-          command: |
-            sudo apt-get update && sudo apt-get install gpg
-            curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
-            curl -Os https://uploader.codecov.io/latest/linux/codecov
-            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
-            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
-            gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
-            shasum -a 256 -c codecov.SHA256SUM
-            chmod +x codecov
-      - run:
-          name: Publish coverage report
-          command: './codecov -f target/coverage/codecov.json'
+      - codecov/upload:
+          files: target/coverage/codecov.json
+          disable_search: true
 
   auth-ldap:
     docker:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ This change log follows the conventions of [keepachangelog.com](http://keepachan
 
 ## [Unreleased]
 
-...
+### Fixed
+- Updated CI configuration and fixed CodeCov integration.
 
 
 ## [2.3.591] - 2026-03-02

--- a/deps.edn
+++ b/deps.edn
@@ -36,7 +36,8 @@
    :jvm-opts ["-Ddialog.profile=test"]
    :main-opts ["-m" "cloverage.coverage"
                "--src-ns-path" "src"
-               "--test-ns-path" "test"]}
+               "--test-ns-path" "test"
+               "--codecov"]}
 
   :hiera
   {:deps {io.github.greglook/clj-hiera {:git/tag "2.0.0", :git/sha "b14e514"}}

--- a/src/vault/auth.clj
+++ b/src/vault/auth.clj
@@ -1,6 +1,6 @@
 (ns vault.auth
   "High-level namespace for client authentication."
-  (:refer-clojure :exclude [set!])
+  (:refer-clojure :exclude [^{:clj-kondo/ignore [:unresolved-excluded-var]} set!])
   (:require
     [clojure.tools.logging :as log]
     [vault.util :as u]))

--- a/src/vault/auth/token.clj
+++ b/src/vault/auth/token.clj
@@ -89,6 +89,21 @@
 
   API
 
+  (create-token!
+    [_ _]
+    (throw (ex-info "Not Implemented" {})))
+
+
+  (create-orphan-token!
+    [_ _]
+    (throw (ex-info "Not Implemented" {})))
+
+
+  (create-role-token!
+    [_ _ _]
+    (throw (ex-info "Not Implemented" {})))
+
+
   (lookup-token
     [client params]
     (let [root-token "r00t"
@@ -122,7 +137,17 @@
           client
           (ex-info "Vault API errors: bad token"
                    {:vault.client/errors ["bad token"]
-                    :vault.client/status 403}))))))
+                    :vault.client/status 403})))))
+
+
+  (renew-token!
+    [_ _]
+    (throw (ex-info "Not Implemented" {})))
+
+
+  (revoke-token!
+    [_ _]
+    (throw (ex-info "Not Implemented" {}))))
 
 
 ;; ## HTTP Client

--- a/src/vault/sys/auth.clj
+++ b/src/vault/sys/auth.clj
@@ -86,6 +86,16 @@
                  :uuid "fcd3aea9-d682-3143-72d3-938c3f666d62"}}))
 
 
+  (enable-method!
+    [_ _ _]
+    (throw (ex-info "Not Implemented" {})))
+
+
+  (disable-method!
+    [_ _]
+    (throw (ex-info "Not Implemented" {})))
+
+
   (read-method-tuning
     [client path]
     (if (= "token" (u/trim-path path))
@@ -101,7 +111,12 @@
         (let [error (str "cannot fetch sysview for path \"" path \")]
           (ex-info (str "Vault API errors: " error)
                    {:vault.client/errors [error]
-                    :vault.client/status 400}))))))
+                    :vault.client/status 400})))))
+
+
+  (tune-method!
+    [_ _ _]
+    (throw (ex-info "Not Implemented" {}))))
 
 
 ;; ## HTTP Client

--- a/test/vault/integration.clj
+++ b/test/vault/integration.clj
@@ -65,7 +65,7 @@
                   "bound on " interface " - check `lsof -i TCP:" port
                   "` and kill the offending process."))))
   (let [command ["vault" "server" "-dev"
-                 (str "-dev-listen-address=" (str interface ":" port))
+                 (str "-dev-listen-address=" interface ":" port)
                  (str "-dev-root-token-id=" root-token)
                  "-dev-no-store-token"]
         work-dir (io/file "target/vault")


### PR DESCRIPTION
Noticed that the coverage check was broken in #110. This updates the CircleCI config to use modern versions of tools and adopt the CodeCov orb instead of the inline version we've been using. I also fixed a few lint issues that the new version of `clj-kondo` surfaced.

Note: codecov is still rejecting the upload, but I think that's because of an org-level setting I'll address separately.